### PR TITLE
Initial cache interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin/
 # third-party dependencies via go mod
 vendor/
-
 # ginkgo test coverage files
 *.coverprofile
+# IntelliJ settings
+.idea/

--- a/internal/app/cache/cache.go
+++ b/internal/app/cache/cache.go
@@ -11,12 +11,6 @@ type Cache interface {
 	// Fetch returns the cached response if it exists.
 	Fetch(key string) (*envoy_api_v2.DiscoveryResponse, error)
 
-	// IsStreamOpen returns false if no stream is opened against the upstream control plane for the given key.
-	IsStreamOpen(key string) (bool, error)
-
-	// SetStreamOpen sets whether there is a stream open against the upstream control plane for the given key.
-	SetStreamOpen(key string, open bool) error
-
 	// SetResponse sets the cache response and returns the list of open watches.
 	SetResponse(key string, resp envoy_api_v2.DiscoveryResponse) ([]*envoy_api_v2.DiscoveryRequest, error)
 

--- a/internal/app/cache/cache.go
+++ b/internal/app/cache/cache.go
@@ -1,7 +1,7 @@
 package cache
 
 import (
-	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	envoy_api_v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
 type Cache interface {
@@ -9,7 +9,7 @@ type Cache interface {
 	Exists(key string) bool
 
 	// Fetch returns the cached response if it exists.
-	Fetch(key string) (*envoy_service_discovery_v3.DiscoveryResponse, error)
+	Fetch(key string) (*envoy_api_v2.DiscoveryResponse, error)
 
 	// IsStreamOpen returns false if no stream is opened against the upstream control plane for the given key.
 	IsStreamOpen(key string) (bool, error)
@@ -18,14 +18,14 @@ type Cache interface {
 	SetStreamOpen(key string, open bool) error
 
 	// SetResponse sets the cache response and returns the list of open watches.
-	SetResponse(key string, resp envoy_service_discovery_v3.DiscoveryResponse) ([]*envoy_service_discovery_v3.DiscoveryRequest, error)
+	SetResponse(key string, resp envoy_api_v2.DiscoveryResponse) ([]*envoy_api_v2.DiscoveryRequest, error)
 
 	// ClearWatches discards the existing watches.
 	ClearWatches(key string) error
 
 	// AddWatch adds the watch to the cache and returns whether a stream is open.
-	AddWatch(key string, req envoy_service_discovery_v3.DiscoveryRequest) (bool, error)
+	AddWatch(key string, req envoy_api_v2.DiscoveryRequest) (bool, error)
 
 	// IsWatchPresent returns whether the given request is watching for the resource corresponding to the given key.
-	IsWatchPresent(key string, req envoy_service_discovery_v3.DiscoveryRequest) (bool, error)
+	IsWatchPresent(key string, req envoy_api_v2.DiscoveryRequest) (bool, error)
 }

--- a/internal/app/cache/cache.go
+++ b/internal/app/cache/cache.go
@@ -14,12 +14,6 @@ type Cache interface {
 	// SetResponse sets the cache response and returns the list of open watches.
 	SetResponse(key string, resp envoy_api_v2.DiscoveryResponse) ([]*envoy_api_v2.DiscoveryRequest, error)
 
-	// ClearWatches discards the existing watches.
-	ClearWatches(key string) error
-
 	// AddWatch adds the watch to the cache and returns whether a stream is open.
 	AddWatch(key string, req envoy_api_v2.DiscoveryRequest) (bool, error)
-
-	// IsWatchPresent returns whether the given request is watching for the resource corresponding to the given key.
-	IsWatchPresent(key string, req envoy_api_v2.DiscoveryRequest) (bool, error)
 }

--- a/internal/app/cache/cache.go
+++ b/internal/app/cache/cache.go
@@ -1,0 +1,31 @@
+package cache
+
+import (
+	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+)
+
+type Cache interface {
+	// Exists returns true if the key exists in the cache, false otherwise.
+	Exists(key string) bool
+
+	// Fetch returns the cached response if it exists.
+	Fetch(key string) (*envoy_service_discovery_v3.DiscoveryResponse, error)
+
+	// IsStreamOpen returns false if no stream is opened against the upstream control plane for the given key.
+	IsStreamOpen(key string) (bool, error)
+
+	// SetStreamOpen sets whether there is a stream open against the upstream control plane for the given key.
+	SetStreamOpen(key string, open bool) error
+
+	// SetResponse sets the cache response and returns the list of open watches.
+	SetResponse(key string, resp envoy_service_discovery_v3.DiscoveryResponse) ([]*envoy_service_discovery_v3.DiscoveryRequest, error)
+
+	// ClearWatches discards the existing watches.
+	ClearWatches(key string) error
+
+	// AddWatch adds the watch to the cache and returns whether a stream is open.
+	AddWatch(key string, req envoy_service_discovery_v3.DiscoveryRequest) (bool, error)
+
+	// IsWatchPresent returns whether the given request is watching for the resource corresponding to the given key.
+	IsWatchPresent(key string, req envoy_service_discovery_v3.DiscoveryRequest) (bool, error)
+}


### PR DESCRIPTION
This change defines the cache interface for an in-memory cache that retains the DiscoveryResponses from the control plane and related watches/stream for a given aggregated key. The methods were defined based on the [sequence diagram](https://docs.google.com/document/d/1X9fFzqBZzrSmx2d0NkmjDW2tc8ysbLQS9LaRQRxdJZU/edit#heading=h.1g62tk7rs8tn) from the tech spec.

Issue: #9 