### PR TITLE
remove typeUrl dependency in mapper

### DIFF
--- a/internal/app/mapper/mapper.go
+++ b/internal/app/mapper/mapper.go
@@ -15,11 +15,11 @@ type rule = aggregationv1.KeyerConfiguration_Fragment_Rule
 type Mapper interface {
 	// GetKey converts a request into an aggregated key
 	// Returns error if the regex parsing in the config fails to compile or match
-	// Returns error if the typeURL is empty. An empty typeURL signifies an ADS request.
-	// ref: envoyproxy/envoy/blob/d1a36f1ea24b38fc414d06ea29c5664f419066ef/api/envoy/api/v2/discovery.proto#L43-L46
-	// ref: envoyproxy/go-control-plane/blob/1152177914f2ec0037411f65c56d9beae526870a/pkg/server/server.go#L305-L310
-	// The go-control-plane will always translate DiscoveryRequest typeURL to one of the resource typeURL.
-	GetKey(request v2.DiscoveryRequest, typeURL string) (string, error)
+	// An DiscoveryRequest will always contain typeUrl
+	// ADS will contain typeUrl https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/discovery.proto#L46
+	// Implicit xds requests will have typeUrl set because go-control-plane mutates the DiscoveeryRequest
+	// ref: https://github.com/envoyproxy/go-control-plane/blob/master/pkg/server/server.go#L310
+	GetKey(request v2.DiscoveryRequest) (string, error)
 }
 
 type mapper struct {
@@ -38,8 +38,8 @@ func NewMapper(config aggregationv1.KeyerConfiguration) Mapper {
 }
 
 // GetKey converts a request into an aggregated key
-func (mapper *mapper) GetKey(request v2.DiscoveryRequest, typeURL string) (string, error) {
-	if typeURL == "" {
+func (mapper *mapper) GetKey(request v2.DiscoveryRequest) (string, error) {
+	if request.GetTypeUrl() == "" {
 		return "", fmt.Errorf("typeURL is empty")
 	}
 
@@ -48,7 +48,7 @@ func (mapper *mapper) GetKey(request v2.DiscoveryRequest, typeURL string) (strin
 		fragmentRules := fragment.GetRules()
 		for _, fragmentRule := range fragmentRules {
 			matchPredicate := fragmentRule.GetMatch()
-			isMatch := isMatch(matchPredicate, typeURL)
+			isMatch := isMatch(matchPredicate, request.GetTypeUrl())
 			if isMatch {
 				result := getResult(fragmentRule)
 				resultFragments = append(resultFragments, result)

--- a/internal/app/mapper/mapper.go
+++ b/internal/app/mapper/mapper.go
@@ -15,9 +15,9 @@ type rule = aggregationv1.KeyerConfiguration_Fragment_Rule
 type Mapper interface {
 	// GetKey converts a request into an aggregated key
 	// Returns error if the regex parsing in the config fails to compile or match
-	// An DiscoveryRequest will always contain typeUrl
+	// A DiscoveryRequest will always contain typeUrl
 	// ADS will contain typeUrl https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/discovery.proto#L46
-	// Implicit xds requests will have typeUrl set because go-control-plane mutates the DiscoveeryRequest
+	// Implicit xds requests will have typeUrl set because go-control-plane mutates the DiscoveryRequest
 	// ref: https://github.com/envoyproxy/go-control-plane/blob/master/pkg/server/server.go#L310
 	GetKey(request v2.DiscoveryRequest) (string, error)
 }

--- a/internal/app/mapper/mapper_test.go
+++ b/internal/app/mapper/mapper_test.go
@@ -145,7 +145,9 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := NewMapper(protoConfig)
-			key, err := mapper.GetKey(getDiscoveryRequest(), typeurl)
+			request := getDiscoveryRequest()
+			request.TypeUrl = typeurl
+			key, err := mapper.GetKey(request)
 			Expect(key).To(Equal(assert))
 			Expect(err).Should(BeNil())
 		}, postivetests...)
@@ -165,7 +167,7 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := NewMapper(protoConfig)
-			key, err := mapper.GetKey(getDiscoveryRequest(), clusterTypeURL)
+			key, err := mapper.GetKey(getDiscoveryRequest())
 			Expect(key).To(Equal(""))
 			Expect(err).Should(Equal(fmt.Errorf("Cannot map the input to a key")))
 		},
@@ -198,7 +200,7 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := NewMapper(protoConfig)
-			key, err := mapper.GetKey(getDiscoveryRequest(), clusterTypeURL)
+			key, err := mapper.GetKey(getDiscoveryRequest())
 			Expect(expectedKey).To(Equal(key))
 			Expect(err).Should(BeNil())
 		},
@@ -227,7 +229,7 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := NewMapper(protoConfig)
-			key, err := mapper.GetKey(getDiscoveryRequest(), clusterTypeURL)
+			key, err := mapper.GetKey(getDiscoveryRequest())
 			Expect(key).To(Equal(""))
 			Expect(err).Should(Equal(fmt.Errorf("Cannot map the input to a key")))
 		},
@@ -235,7 +237,9 @@ var _ = Describe("GetKey", func() {
 
 	It("TypeUrl should not be empty", func() {
 		mapper := NewMapper(KeyerConfiguration{})
-		key, err := mapper.GetKey(getDiscoveryRequest(), "")
+		request := getDiscoveryRequest()
+		request.TypeUrl = ""
+		key, err := mapper.GetKey(request)
 		Expect(key).To(Equal(""))
 		Expect(err).Should(Equal(fmt.Errorf("typeURL is empty")))
 	})


### PR DESCRIPTION
DiscoveryRequest will always contain typeUrl
ADS will contain typeUrl https://github.com/envoyproxy/envoy/blob/master/api/envoy/api/v2/discovery.proto#L46
Implicit xds requests will have typeUrl set because go-control-plane mutates the DiscoveryRequest
ref: https://github.com/envoyproxy/go-control-plane/blob/master/pkg/server/server.go#L310