### PR TITLE
Fix Makefile and dependency errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export SERVICE_NAME=xds-relay
 .PHONY: compile
 compile: ## Compiles the binary and installs it into /usr/local/bin
 	mkdir -p ./bin && \
-	  go build -o ./bin/ && \
+	  go build -o ./bin/${SERVICE_NAME} && \
 	  cp ./bin/${SERVICE_NAME} /usr/local/bin/${SERVICE_NAME}
 
 .PHONY: install

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/envoyproxy/go-control-plane v0.9.4
-	github.com/envoyproxy/protoc-gen-validate v0.1.0
+	github.com/envoyproxy/protoc-gen-validate v0.3.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.0-rc.4
 	github.com/onsi/ginkgo v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/envoyproxy/go-control-plane v0.9.4
-	github.com/envoyproxy/protoc-gen-validate v0.3.0
+	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.4.0-rc.4
 	github.com/onsi/ginkgo v1.12.0


### PR DESCRIPTION
Errors:
```
> make compile
mkdir -p ./bin && \
	  go build -o ./bin/ && \
	  cp ./bin/xds-relay /usr/local/bin/xds-relay
go build github.com/envoyproxy/xds-relay: build output "./bin/" already exists and is a directory
make: *** [compile] Error 1
```

`go: github.com/envoyproxy/protoc-gen-validate@v0.3.0: unknown revision v0.3.0`

Signed-off-by: Jess Yuen <jyuen@lyft.com>