### PR TITLE
Add logging interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/protobuf v1.4.0-rc.4
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
+	github.com/stretchr/testify v1.4.0
 	go.uber.org/zap v1.14.0
 	google.golang.org/grpc v1.27.1
 	google.golang.org/protobuf v1.20.1

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -12,10 +12,12 @@ import (
 	"google.golang.org/grpc"
 )
 
+const defaultLogLevel = "info" // TODO make configurable
+
 // Run instantiates a running gRPC server for accepting incoming xDS-based
 // requests.
 func Run() {
-	logger := log.New().Sugar()
+	logger := log.New(defaultLogLevel)
 
 	// Cursory implementation of go-control-plane's server.
 	// TODO cancel should be invoked by shutdown handlers.
@@ -27,7 +29,7 @@ func Run() {
 	server := grpc.NewServer()
 	listener, err := net.Listen("tcp", ":8080") // #nosec
 	if err != nil {
-		logger.Fatalw("failed to bind server to listener", "err", err)
+		logger.With("err", err).Fatal(ctx, "failed to bind server to listener")
 	}
 
 	api.RegisterEndpointDiscoveryServiceServer(server, gcpServer)
@@ -35,8 +37,8 @@ func Run() {
 	api.RegisterRouteDiscoveryServiceServer(server, gcpServer)
 	api.RegisterListenerDiscoveryServiceServer(server, gcpServer)
 
-	logger.Info("Initializing server at", listener.Addr().String())
+	logger.With("address", listener.Addr()).Info(ctx, "Initializing server")
 	if err := server.Serve(listener); err != nil {
-		logger.Fatalw("failed to initialize server", "err", err)
+		logger.With("err", err).Fatal(ctx, "failed to initialize server")
 	}
 }

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -1,12 +1,10 @@
-// Package log configures a logger using the Zap logging framework.
+// Package log defines the contract for the xds-relay logger.
+// It also contains an implementation of the contract using the Zap logging
+// framework.
 package log
 
 import (
 	"context"
-
-	"github.com/envoyproxy/xds-relay/internal/pkg/log/zap"
-
-	z "go.uber.org/zap"
 )
 
 // Logger is the contract for xds-relay's logging implementation.
@@ -57,68 +55,4 @@ type Logger interface {
 
 	// Sync flushes any buffered log entries.
 	Sync() error
-}
-
-type logger struct {
-	zap *z.SugaredLogger
-}
-
-// New returns an instance of Logger implemented using the Zap logging framework.
-func New(logLevel string) Logger {
-	zLevel, parseLogLevelErr := zap.ParseLogLevel(logLevel)
-
-	log := zap.New(
-		zap.Level(&zLevel),
-		// CallerSkip skips 1 number of callers, otherwise the file that gets
-		// logged will always be the wrapped file. In this case, log.go.
-		zap.AddCallerSkip(1),
-	)
-
-	if parseLogLevelErr != nil {
-		// Log an invalid log level error and set the default level to info.
-		log.Error("cannot set logger to desired log level")
-	}
-	return &logger{zap: log.Sugar()}
-}
-
-func (l *logger) Named(name string) Logger {
-	l.zap = l.zap.Named(name)
-	return l
-}
-
-func (l *logger) With(args ...interface{}) Logger {
-	l.zap = l.zap.With(args...)
-	return l
-}
-
-func (l *logger) WithContext(ctx context.Context) *logger {
-	// We can add origin xDS request context here later.
-	// For now, just return the logger.
-	return l
-}
-
-func (l *logger) Sync() error { return l.zap.Sync() }
-
-func (l *logger) Debug(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Debug(args...)
-}
-
-func (l *logger) Info(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Info(args...)
-}
-
-func (l *logger) Warn(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Warn(args...)
-}
-
-func (l *logger) Error(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Error(args...)
-}
-
-func (l *logger) Fatal(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Fatal(args...)
-}
-
-func (l *logger) Panic(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Panic(args...)
 }

--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -1,0 +1,72 @@
+package log
+
+import (
+	"context"
+
+	"github.com/envoyproxy/xds-relay/internal/pkg/log/zap"
+	z "go.uber.org/zap"
+)
+
+type logger struct {
+	zap *z.SugaredLogger
+}
+
+// New returns an instance of Logger implemented using the Zap logging framework.
+func New(logLevel string) Logger {
+	zLevel, parseLogLevelErr := zap.ParseLogLevel(logLevel)
+
+	log := zap.New(
+		zap.Level(&zLevel),
+		// CallerSkip skips 1 number of callers, otherwise the file that gets
+		// logged will always be the wrapped file. In this case, log.go.
+		zap.AddCallerSkip(1),
+	)
+
+	if parseLogLevelErr != nil {
+		// Log an invalid log level error and set the default level to info.
+		log.Error("cannot set logger to desired log level")
+	}
+	return &logger{zap: log.Sugar()}
+}
+
+func (l *logger) Named(name string) Logger {
+	l.zap = l.zap.Named(name)
+	return l
+}
+
+func (l *logger) With(args ...interface{}) Logger {
+	l.zap = l.zap.With(args...)
+	return l
+}
+
+func (l *logger) WithContext(ctx context.Context) *logger {
+	// We can add origin xDS request context here later.
+	// For now, just return the logger.
+	return l
+}
+
+func (l *logger) Sync() error { return l.zap.Sync() }
+
+func (l *logger) Debug(ctx context.Context, args ...interface{}) {
+	l.WithContext(ctx).zap.Debug(args...)
+}
+
+func (l *logger) Info(ctx context.Context, args ...interface{}) {
+	l.WithContext(ctx).zap.Info(args...)
+}
+
+func (l *logger) Warn(ctx context.Context, args ...interface{}) {
+	l.WithContext(ctx).zap.Warn(args...)
+}
+
+func (l *logger) Error(ctx context.Context, args ...interface{}) {
+	l.WithContext(ctx).zap.Error(args...)
+}
+
+func (l *logger) Fatal(ctx context.Context, args ...interface{}) {
+	l.WithContext(ctx).zap.Fatal(args...)
+}
+
+func (l *logger) Panic(ctx context.Context, args ...interface{}) {
+	l.WithContext(ctx).zap.Panic(args...)
+}

--- a/internal/pkg/log/zap/zap.go
+++ b/internal/pkg/log/zap/zap.go
@@ -62,9 +62,7 @@ func New(opts ...Opts) *zap.Logger {
 		opt(o)
 	}
 	o.addDefaults()
-
 	sink := zapcore.AddSync(o.OutputDest)
-
 	o.ZapOptions = append(o.ZapOptions, zap.AddCallerSkip(o.CallerSkip), zap.ErrorOutput(sink))
 	log := zap.New(zapcore.NewCore(o.Encoder, sink, *o.Level))
 	log = log.WithOptions(o.ZapOptions...)

--- a/internal/pkg/log/zap/zap.go
+++ b/internal/pkg/log/zap/zap.go
@@ -1,4 +1,6 @@
-// Package zap sets up a logger using the Zap logging framework.
+// Package zap sets up a zap.Logger using the Zap logging framework.
+// This implementation contains configurable options including log levels,
+// stack trace levels, encoders, and caller skip levels.
 package zap
 
 import (

--- a/internal/pkg/log/zap/zap.go
+++ b/internal/pkg/log/zap/zap.go
@@ -9,63 +9,63 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// Options contains all possible log settings.
-type Options struct {
-	// CallerSkip
-	CallerSkip int
-	// Level configures the log verbosity. Defaults to Debug.
-	Level *zap.AtomicLevel
-	// StacktraceLevel is the level which stacktraces will be emitted. Defaults
+// options contains all possible log settings.
+type options struct {
+	// callerSkip increases the number of callers skipped by caller annotation.
+	callerSkip int
+	// level configures the log verbosity. Defaults to Debug.
+	level *zap.AtomicLevel
+	// stacktraceLevel is the level which stacktraces will be emitted. Defaults
 	// to Warn.
-	StacktraceLevel *zap.AtomicLevel
-	// Encoder configures how Zap will encode the output. Defaults to JSON.
-	Encoder zapcore.Encoder
-	// OutputDest controls the destination of the log output. Defaults to
+	stacktraceLevel *zap.AtomicLevel
+	// encoder configures how Zap will encode the output. Defaults to JSON.
+	encoder zapcore.Encoder
+	// outputDest controls the destination of the log output. Defaults to
 	// os.Stderr.
-	OutputDest io.Writer
-	// ZapOptions allows passing additional optional zap.Options, ex: Sampling.
-	ZapOptions []zap.Option
+	outputDest io.Writer
+	// zapOptions allows passing additional optional zap.Options, ex: Sampling.
+	zapOptions []zap.Option
 }
 
 // Opts allows manipulation of the Zap options.
-type Opts func(*Options)
+type Opts func(*options)
 
 // addDefaults adds defaults to the Options
-func (o *Options) addDefaults() {
-	if o.CallerSkip < 1 {
-		o.CallerSkip = 1
+func (o *options) addDefaults() {
+	if o.callerSkip < 1 {
+		o.callerSkip = 1
 	}
-	if o.OutputDest == nil {
-		o.OutputDest = os.Stderr
+	if o.outputDest == nil {
+		o.outputDest = os.Stderr
 	}
-	if o.Encoder == nil {
+	if o.encoder == nil {
 		encCfg := zap.NewProductionEncoderConfig()
-		o.Encoder = zapcore.NewJSONEncoder(encCfg)
+		o.encoder = zapcore.NewJSONEncoder(encCfg)
 	}
-	if o.Level == nil {
+	if o.level == nil {
 		level := zap.NewAtomicLevelAt(zap.DebugLevel)
-		o.Level = &level
+		o.level = &level
 	}
-	if o.StacktraceLevel == nil {
+	if o.stacktraceLevel == nil {
 		level := zap.NewAtomicLevelAt(zap.WarnLevel)
-		o.StacktraceLevel = &level
+		o.stacktraceLevel = &level
 	}
 
-	o.ZapOptions = append(o.ZapOptions, zap.AddStacktrace(o.StacktraceLevel))
+	o.zapOptions = append(o.zapOptions, zap.AddStacktrace(o.stacktraceLevel))
 }
 
 // New returns a new zap.Logger configured with the passed Options or their
 // defaults.
 func New(opts ...Opts) *zap.Logger {
-	o := &Options{}
+	o := &options{}
 	for _, opt := range opts {
 		opt(o)
 	}
 	o.addDefaults()
-	sink := zapcore.AddSync(o.OutputDest)
-	o.ZapOptions = append(o.ZapOptions, zap.AddCallerSkip(o.CallerSkip), zap.ErrorOutput(sink))
-	log := zap.New(zapcore.NewCore(o.Encoder, sink, *o.Level))
-	log = log.WithOptions(o.ZapOptions...)
+	sink := zapcore.AddSync(o.outputDest)
+	o.zapOptions = append(o.zapOptions, zap.AddCallerSkip(o.callerSkip), zap.ErrorOutput(sink))
+	log := zap.New(zapcore.NewCore(o.encoder, sink, *o.level))
+	log = log.WithOptions(o.zapOptions...)
 	return log
 }
 
@@ -73,47 +73,47 @@ func New(opts ...Opts) *zap.Logger {
 // supplying this Option prevents zap from always reporting the wrapper code as
 // the caller.
 func AddCallerSkip(skip int) Opts {
-	return func(o *Options) {
-		o.CallerSkip = o.CallerSkip + skip
+	return func(o *options) {
+		o.callerSkip = o.callerSkip + skip
 	}
 }
 
 // WriteTo configures the logger to write to the given io.Writer, instead of
 // stderr. See Options.OutputDest.
 func WriteTo(out io.Writer) Opts {
-	return func(o *Options) {
-		o.OutputDest = out
+	return func(o *options) {
+		o.outputDest = out
 	}
 }
 
 // Encoder configures how the logger will encode the output e.g console, JSON.
 // See Options.Encoder.
 func Encoder(encoder zapcore.Encoder) Opts {
-	return func(o *Options) {
-		o.Encoder = encoder
+	return func(o *options) {
+		o.encoder = encoder
 	}
 }
 
 // Level sets the the minimum enabled logging level e.g Debug, Info, Warn,
 // Error. See Options.Level.
 func Level(level *zap.AtomicLevel) Opts {
-	return func(o *Options) {
-		o.Level = level
+	return func(o *options) {
+		o.level = level
 	}
 }
 
 // StacktraceLevel configures the logger to record a stack trace for all messages at
 // or above the given level. See Options.StacktraceLevel.
 func StacktraceLevel(stacktraceLevel *zap.AtomicLevel) Opts {
-	return func(o *Options) {
-		o.StacktraceLevel = stacktraceLevel
+	return func(o *options) {
+		o.stacktraceLevel = stacktraceLevel
 	}
 }
 
 // RawOptions allows appending additional zap.Options. See Options.ZapOptions.
-func RawOptions(options ...zap.Option) Opts {
-	return func(o *Options) {
-		o.ZapOptions = append(o.ZapOptions, options...)
+func RawOptions(opts ...zap.Option) Opts {
+	return func(o *options) {
+		o.zapOptions = append(o.zapOptions, opts...)
 	}
 }
 

--- a/internal/pkg/log/zap/zap.go
+++ b/internal/pkg/log/zap/zap.go
@@ -1,0 +1,128 @@
+// Package zap sets up a logger using the Zap logging framework.
+package zap
+
+import (
+	"io"
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Options contains all possible log settings.
+type Options struct {
+	// CallerSkip
+	CallerSkip int
+	// Level configures the log verbosity. Defaults to Debug.
+	Level *zap.AtomicLevel
+	// StacktraceLevel is the level which stacktraces will be emitted. Defaults
+	// to Warn.
+	StacktraceLevel *zap.AtomicLevel
+	// Encoder configures how Zap will encode the output. Defaults to JSON.
+	Encoder zapcore.Encoder
+	// OutputDest controls the destination of the log output. Defaults to
+	// os.Stderr.
+	OutputDest io.Writer
+	// ZapOptions allows passing additional optional zap.Options, ex: Sampling.
+	ZapOptions []zap.Option
+}
+
+// Opts allows manipulation of the Zap options.
+type Opts func(*Options)
+
+// addDefaults adds defaults to the Options
+func (o *Options) addDefaults() {
+	if o.CallerSkip < 1 {
+		o.CallerSkip = 1
+	}
+	if o.OutputDest == nil {
+		o.OutputDest = os.Stderr
+	}
+	if o.Encoder == nil {
+		encCfg := zap.NewProductionEncoderConfig()
+		o.Encoder = zapcore.NewJSONEncoder(encCfg)
+	}
+	if o.Level == nil {
+		level := zap.NewAtomicLevelAt(zap.DebugLevel)
+		o.Level = &level
+	}
+	if o.StacktraceLevel == nil {
+		level := zap.NewAtomicLevelAt(zap.WarnLevel)
+		o.StacktraceLevel = &level
+	}
+
+	o.ZapOptions = append(o.ZapOptions, zap.AddStacktrace(o.StacktraceLevel))
+}
+
+// New returns a new zap.Logger configured with the passed Options or their
+// defaults.
+func New(opts ...Opts) *zap.Logger {
+	o := &Options{}
+	for _, opt := range opts {
+		opt(o)
+	}
+	o.addDefaults()
+
+	sink := zapcore.AddSync(o.OutputDest)
+
+	o.ZapOptions = append(o.ZapOptions, zap.AddCallerSkip(o.CallerSkip), zap.ErrorOutput(sink))
+	log := zap.New(zapcore.NewCore(o.Encoder, sink, *o.Level))
+	log = log.WithOptions(o.ZapOptions...)
+	return log
+}
+
+// AddCallerSkip increases the number of callers skipped by caller annotation,
+// supplying this Option prevents zap from always reporting the wrapper code as
+// the caller.
+func AddCallerSkip(skip int) Opts {
+	return func(o *Options) {
+		o.CallerSkip = o.CallerSkip + skip
+	}
+}
+
+// WriteTo configures the logger to write to the given io.Writer, instead of
+// stderr. See Options.OutputDest.
+func WriteTo(out io.Writer) Opts {
+	return func(o *Options) {
+		o.OutputDest = out
+	}
+}
+
+// Encoder configures how the logger will encode the output e.g console, JSON.
+// See Options.Encoder.
+func Encoder(encoder zapcore.Encoder) Opts {
+	return func(o *Options) {
+		o.Encoder = encoder
+	}
+}
+
+// Level sets the the minimum enabled logging level e.g Debug, Info, Warn,
+// Error. See Options.Level.
+func Level(level *zap.AtomicLevel) Opts {
+	return func(o *Options) {
+		o.Level = level
+	}
+}
+
+// StacktraceLevel configures the logger to record a stack trace for all messages at
+// or above the given level. See Options.StacktraceLevel.
+func StacktraceLevel(stacktraceLevel *zap.AtomicLevel) Opts {
+	return func(o *Options) {
+		o.StacktraceLevel = stacktraceLevel
+	}
+}
+
+// RawOptions allows appending additional zap.Options. See Options.ZapOptions.
+func RawOptions(options ...zap.Option) Opts {
+	return func(o *Options) {
+		o.ZapOptions = append(o.ZapOptions, options...)
+	}
+}
+
+// ParseLogLevel accepts either a capitalized or lower cased string for the log
+// level. Accepts one of "debug", "info", "warn", "error", "panic", or "fatal".
+// Returns zap.InfoLevel on an error.
+func ParseLogLevel(logLevel string) (zap.AtomicLevel, error) {
+	l := zap.NewAtomicLevel()
+	return l, l.UnmarshalText([]byte(logLevel))
+}

--- a/internal/pkg/log/zap/zap_suite_test.go
+++ b/internal/pkg/log/zap/zap_suite_test.go
@@ -1,4 +1,4 @@
-package log_test
+package zap_test
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestLog(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Log Suite")
+	RunSpecs(t, "Zap Log Suite")
 }

--- a/internal/pkg/log/zap/zap_test.go
+++ b/internal/pkg/log/zap/zap_test.go
@@ -17,16 +17,16 @@ func (w *mockWriter) Write(p []byte) (int, error) {
 }
 
 var _ = Describe("Zap options setup", func() {
-	var opts *Options
+	var opts *options
 
 	BeforeEach(func() {
-		opts = &Options{}
+		opts = &options{}
 	})
 
 	It("should set a custom writer", func() {
 		var w mockWriter
 		WriteTo(&w)(opts)
-		Expect(opts.OutputDest).To(Equal(&w))
+		Expect(opts.outputDest).To(Equal(&w))
 	})
 })
 

--- a/internal/pkg/log/zap/zap_test.go
+++ b/internal/pkg/log/zap/zap_test.go
@@ -1,6 +1,7 @@
-package log
+package zap
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	. "github.com/onsi/ginkgo"
@@ -42,5 +43,19 @@ var _ = Describe("Initializing new Zap logger", func() {
 			encoder := zapcore.NewConsoleEncoder(cfg)
 			Expect(New(WriteTo(ioutil.Discard), Encoder(encoder))).NotTo(BeNil())
 		})
+	})
+})
+
+var _ = Describe("Parse log level", func() {
+	It("should set specified log level", func() {
+		level, err := ParseLogLevel("error")
+		Expect(err).To(BeNil())
+		Expect(level).To(Equal(zap.NewAtomicLevelAt(zap.ErrorLevel)))
+	})
+
+	It("should set info level if invalid string is provided", func() {
+		level, err := ParseLogLevel("not a valid log level")
+		Expect(err).To(Equal(fmt.Errorf(`unrecognized level: "not a valid log level"`)))
+		Expect(level).To(Equal(zap.NewAtomicLevelAt(zap.InfoLevel)))
 	})
 })

--- a/internal/pkg/log/zap_test.go
+++ b/internal/pkg/log/zap_test.go
@@ -1,0 +1,34 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	// assert all types returns a non-nil logger.
+	tests := []struct {
+		name     string
+		logLevel string
+	}{
+		{
+			name:     "log level info",
+			logLevel: "info",
+		},
+		{
+			name:     "log level warn",
+			logLevel: "warn",
+		},
+		{
+			name:     "log level invalid",
+			logLevel: "invalid",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := New(tt.logLevel)
+			assert.NotNil(t, got)
+		})
+	}
+}


### PR DESCRIPTION
This adds a custom logging interface infront of the zap logger in order
to supply context and friendlier `With` structured logging, ex:

```
    Log.Named("foo-component").With(
        "field1", "value1",
        "field2", "value2",
     ).Error("my error message")
```

Also decouples the 3rd party library code from slipping into other areas
of the application.

Signed-off-by: Jess Yuen <jyuen@lyft.com>