### PR TITLE
Orchestrator interface

### DIFF
--- a/internal/app/cache/gcp_cache.go
+++ b/internal/app/cache/gcp_cache.go
@@ -1,0 +1,50 @@
+package cache
+
+import (
+	"context"
+
+	discovery "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	gcp "github.com/envoyproxy/go-control-plane/pkg/cache"
+	orchestrator "github.com/envoyproxy/xds-relay/internal/app/orchestrator"
+)
+
+// GcpCache is the implementation that implements the functions needed for integrating with go-control-plane
+// It implements the CreateWatch function which is required to create xds grpc streams with sidecars.
+type GcpCache struct {
+	orchestrator orchestrator.Orchestrator
+}
+
+// NewGcpCache creates an instance of GcpCache
+func NewGcpCache(orchestrator orchestrator.Orchestrator) *GcpCache {
+	return &GcpCache{
+		orchestrator: orchestrator,
+	}
+}
+
+// CreateWatch returns a new open watch from a non-empty request.
+//
+// Value channel produces requested resources, once they are available.  If
+// the channel is closed prior to cancellation of the watch, an unrecoverable
+// error has occurred in the producer, and the consumer should close the
+// corresponding stream.
+//
+// Cancel is an optional function to release resources in the producer. If
+// provided, the consumer may call this function multiple times.
+func (c *GcpCache) CreateWatch(req gcp.Request) (chan gcp.Response, func()) {
+	return c.orchestrator.CreateWatch(req)
+}
+
+// Fetch implements the polling method of the config cache using a non-empty request.
+func (c *GcpCache) Fetch(context.Context, discovery.DiscoveryRequest) (*gcp.Response, error) {
+	return nil, nil
+}
+
+// GetStatusInfo retrieves status information for a node ID.
+func (c *GcpCache) GetStatusInfo(string) gcp.StatusInfo {
+	return nil
+}
+
+// GetStatusKeys retrieves node IDs for all statuses.
+func (c *GcpCache) GetStatusKeys() []string {
+	return nil
+}

--- a/internal/app/cache/gcp_cache.go
+++ b/internal/app/cache/gcp_cache.go
@@ -5,16 +5,16 @@ import (
 
 	discovery "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache"
-	orchestrator "github.com/envoyproxy/xds-relay/internal/app/orchestrator"
+	"github.com/envoyproxy/xds-relay/internal/app/orchestrator"
 )
 
-// GcpCache is the implementation that implements the functions needed for integrating with go-control-plane
-// It implements the CreateWatch function which is required to create xds grpc streams with sidecars.
+// GcpCache implements the cache needed for integrating with go-control-plane.
+// It implements the CreateWatch function which is required to create xDS gRPC streams with xDS clients.
 type GcpCache struct {
 	orchestrator orchestrator.Orchestrator
 }
 
-// NewGcpCache creates an instance of GcpCache
+// NewGcpCache creates an instance of GcpCache.
 func NewGcpCache(orchestrator orchestrator.Orchestrator) *GcpCache {
 	return &GcpCache{
 		orchestrator: orchestrator,

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -4,20 +4,19 @@ import (
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache"
 )
 
-// Orchestrator provides an interface that handles the discovery requests from sidecars.
+// Orchestrator provides an interface that handles the discovery requests from xDS clients.
+// The orchestrator maintains all the relevant caches and makes sure of the following:
+// 1. Returns long lived streams from the xDS clients.
+// 2. Aggregates similar requests abiding by the aggregated keyer configurations.
+// 3. Maintains upstream request streams with the upstream origin server for each such unique discovery request.
+// 4. When a new response is available on the origin server,
+//    orchestrator relays the response back on the streams associated with the xDS clients.
 type Orchestrator interface {
 	// CreateWatch returns a new open watch from a non-empty request.
 	// Returns a channel with Response and a function which is a callback for handling stream cancellations.
 	CreateWatch(req gcp.Request) (chan gcp.Response, func())
 }
 
-// orchestrator provides a mechanism to implement the Orchestrator interface.
-// The orchestrator maintains all the relevant caches and makes sure of the following:
-// 1. Returns long lived streams from the sidecars.
-// 2. Aggregates similar requests from a key.
-// 3. Maintains upstream request streams with the upstream origin server for each such unique discovery request.
-// 4. When a new response is available on the origin server,
-//    orchestrator relays the response back on the streams associated with the sidecars.
 type orchestrator struct {
 }
 

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -1,0 +1,31 @@
+package orchestrator
+
+import (
+	gcp "github.com/envoyproxy/go-control-plane/pkg/cache"
+)
+
+// Orchestrator provides an interface that handles the discovery requests from sidecars.
+type Orchestrator interface {
+	// CreateWatch returns a new open watch from a non-empty request.
+	// Returns a channel with Response and a function which is a callback for handling stream cancellations.
+	CreateWatch(req gcp.Request) (chan gcp.Response, func())
+}
+
+// orchestrator provides a mechanism to implement the Orchestrator interface.
+// The orchestrator maintains all the relevant caches and makes sure of the following:
+// 1. Returns long lived streams from the sidecars.
+// 2. Aggregates similar requests from a key.
+// 3. Maintains upstream request streams with the upstream origin server for each such unique discovery request.
+// 4. When a new response is available on the origin server,
+//    orchestrator relays the response back on the streams associated with the sidecars.
+type orchestrator struct {
+}
+
+// NewOrchestrator returns an instance of an orchestrator
+func NewOrchestrator() Orchestrator {
+	return &orchestrator{}
+}
+
+func (c *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) {
+	return nil, nil
+}

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -8,8 +8,8 @@ import (
 
 	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	gcp "github.com/envoyproxy/go-control-plane/pkg/server"
-	internalcache "github.com/envoyproxy/xds-relay/internal/app/cache"
-	orchestrator "github.com/envoyproxy/xds-relay/internal/app/orchestrator"
+	"github.com/envoyproxy/xds-relay/internal/app/cache"
+	"github.com/envoyproxy/xds-relay/internal/app/orchestrator"
 	"google.golang.org/grpc"
 )
 
@@ -23,7 +23,7 @@ func Run() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	gcpCache := internalcache.NewGcpCache(orchestrator.NewOrchestrator())
+	gcpCache := cache.NewGcpCache(orchestrator.NewOrchestrator())
 	gcpServer := gcp.NewServer(ctx, gcpCache, nil)
 	server := grpc.NewServer()
 	listener, err := net.Listen("tcp", ":8080") // #nosec

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -7,8 +7,9 @@ import (
 	"github.com/envoyproxy/xds-relay/internal/pkg/log"
 
 	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	gcp "github.com/envoyproxy/go-control-plane/pkg/server"
+	internalcache "github.com/envoyproxy/xds-relay/internal/app/cache"
+	orchestrator "github.com/envoyproxy/xds-relay/internal/app/orchestrator"
 	"google.golang.org/grpc"
 )
 
@@ -22,8 +23,8 @@ func Run() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	snapshotCache := cache.NewSnapshotCache(false, cache.IDHash{}, nil)
-	gcpServer := gcp.NewServer(ctx, snapshotCache, nil)
+	gcpCache := internalcache.NewGcpCache(orchestrator.NewOrchestrator())
+	gcpServer := gcp.NewServer(ctx, gcpCache, nil)
 	server := grpc.NewServer()
 	listener, err := net.Listen("tcp", ":8080") // #nosec
 	if err != nil {


### PR DESCRIPTION
This PR attempts to put an interface for the orchestrator interface.
This is necessary to put these pieces in place so that we can recognize the integration points with go-control-plane and introduce the concept of channels in our interfaces.

This will also help crystallize how the xdsclient interface is going to look like.