### PR TITLE
Use tags to mark integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 export SERVICE_NAME=xds-relay
 
-# We exclude integration tests files because we do not want to run those in unit tests
-SOURCE_FILES?=$$(go list ./... | grep -v integration)
-
 .PHONY: setup
 setup:
 	mkdir -p ./bin
@@ -18,11 +15,11 @@ install: ## Installs dependencies
 
 .PHONY: unit
 unit: ## Run all unit tests with coverage report
-	go test -v -cover $(SOURCE_FILES)
+	go test -v -cover ./...
 
 .PHONY: integration-tests
 integration-tests:  ## Run integration tests
-	go test -v ./integration/
+	go test -tags integration -v ./integration/
 
 .PHONY: compile-protos
 compile-protos: ## Compile proto files

--- a/integration/validator_tool_test.go
+++ b/integration/validator_tool_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration
 
 import (


### PR DESCRIPTION
This PR removes the hack to list test files using `go list` in favor of the more idiomatic way of setting [build tags](https://golang.org/pkg/go/build/#hdr-Build_Constraints) to segment integration tests.

Build tags are opt-in, that's why they are useful for stuff like integration tests. This means that in order for tagged files to show up we have to specify the tags, so in this case we tag all integration tests as `integration` and specify that tag in the `integration-tests` make rule.