### PR TITLE
Don't extend TTL for AddWatch

### DIFF
--- a/internal/app/cache/cache.go
+++ b/internal/app/cache/cache.go
@@ -154,7 +154,6 @@ func (c *cache) AddRequest(key string, req v2.DiscoveryRequest) error {
 		return fmt.Errorf("unable to cast cache value to type resource for key: %s", key)
 	}
 	resource.Requests = append(resource.Requests, &req)
-	resource.ExpirationTime = c.getExpirationTime(time.Now())
 	c.cache.Add(key, resource)
 	return nil
 }


### PR DESCRIPTION
Fixes #58 

The expiration time should only be delayed in SetResponse, since the intent of the TTL was to avoid stale responses in the cache. Adding/removing watches should not affect the expiration time of a key. This change removes that extension from AddWatch, and #59 already omits the expiry time extension.