### PR TITLE
logger: Fix scope creep

### DIFF
--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -79,7 +79,8 @@ type version struct {
 // The method does not block until the underlying connection is up.
 // Returns immediately and connecting the server happens in background
 func NewClient(ctx context.Context, url string, callOptions CallOptions, logger log.Logger) (Client, error) {
-	logger.Info(ctx, "Initiating upstream connection.")
+	namedLogger := logger.Named("upstream_client")
+	namedLogger.With("address", url).Info(ctx, "Initiating upstream connection")
 	// TODO: configure grpc options.https://github.com/envoyproxy/xds-relay/issues/55
 	conn, err := grpc.Dial(url, grpc.WithInsecure())
 	if err != nil {
@@ -99,7 +100,7 @@ func NewClient(ctx context.Context, url string, callOptions CallOptions, logger 
 		edsClient:   edsClient,
 		cdsClient:   cdsClient,
 		callOptions: callOptions,
-		logger:      logger,
+		logger:      namedLogger,
 	}, nil
 }
 

--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -30,13 +30,11 @@ func New(logLevel string) Logger {
 }
 
 func (l *logger) Named(name string) Logger {
-	l.zap = l.zap.Named(name)
-	return l
+	return &logger{zap: l.zap.Named(name)}
 }
 
 func (l *logger) With(args ...interface{}) Logger {
-	l.zap = l.zap.With(args...)
-	return l
+	return &logger{zap: l.zap.With(args...)}
 }
 
 func (l *logger) WithContext(ctx context.Context) *logger {


### PR DESCRIPTION
Fix logging scope creep when chaining.

Issue: https://github.com/envoyproxy/xds-relay/issues/80

After fix:
```
{"level":"info","ts":1589236218.714848,"logger":"upstream_client","msg":"Initiating upstream connection","address":"127.0.0.1:18000"}
{"level":"info","ts":1589236218.715483,"msg":"Initializing server","address":"127.0.0.1:9991"}
^C{"level":"info","ts":1589236225.771179,"msg":"received interrupt signal:interrupt"}
{"level":"info","ts":1589236225.771255,"msg":"initiating grpc graceful stop"}
```

vs Prior:
```
{"level":"info","ts":1589236161.250703,"logger":"upstream_client","msg":"Initiating upstream connection","address":"127.0.0.1:18000"}
{"level":"info","ts":1589236161.251442,"logger":"upstream_client.orchestrator","msg":"Initializing server","address":"127.0.0.1:18000","address":"127.0.0.1:9991"}
^C{"level":"info","ts":1589236162.376368,"logger":"upstream_client.orchestrator","msg":"received interrupt signal:interrupt","address":"127.0.0.1:18000","address":"127.0.0.1:9991"}
{"level":"info","ts":1589236162.376529,"logger":"upstream_client.orchestrator","msg":"initiating grpc graceful stop","address":"127.0.0.1:18000","address":"127.0.0.1:9991"}
```

Signed-off-by: Jess Yuen <jyuen@lyft.com>