### PR TITLE
logger: Support formatted logging

### DIFF
--- a/integration/logger.go
+++ b/integration/logger.go
@@ -11,18 +11,18 @@ type gcpLogger struct {
 	logger log.Logger
 }
 
-func (logger gcpLogger) Debugf(format string, args ...interface{}) {
-	logger.logger.Debug(context.Background(), format, args)
+func (gcp gcpLogger) Debugf(format string, args ...interface{}) {
+	gcp.logger.Debugf(context.Background(), format, args)
 }
 
-func (logger gcpLogger) Infof(format string, args ...interface{}) {
-	logger.logger.Info(context.Background(), format, args)
+func (gcp gcpLogger) Infof(format string, args ...interface{}) {
+	gcp.logger.Infof(context.Background(), format, args)
 }
 
-func (logger gcpLogger) Warnf(format string, args ...interface{}) {
-	logger.logger.Warn(context.Background(), format, args)
+func (gcp gcpLogger) Warnf(format string, args ...interface{}) {
+	gcp.logger.Warnf(context.Background(), format, args)
 }
 
-func (logger gcpLogger) Errorf(format string, args ...interface{}) {
-	logger.logger.Error(context.Background(), format, args)
+func (gcp gcpLogger) Errorf(format string, args ...interface{}) {
+	gcp.logger.Errorf(context.Background(), format, args)
 }

--- a/integration/logger.go
+++ b/integration/logger.go
@@ -12,17 +12,17 @@ type gcpLogger struct {
 }
 
 func (gcp gcpLogger) Debugf(format string, args ...interface{}) {
-	gcp.logger.Debugf(context.Background(), format, args)
+	gcp.logger.Debug(context.Background(), format, args)
 }
 
 func (gcp gcpLogger) Infof(format string, args ...interface{}) {
-	gcp.logger.Infof(context.Background(), format, args)
+	gcp.logger.Info(context.Background(), format, args)
 }
 
 func (gcp gcpLogger) Warnf(format string, args ...interface{}) {
-	gcp.logger.Warnf(context.Background(), format, args)
+	gcp.logger.Warn(context.Background(), format, args)
 }
 
 func (gcp gcpLogger) Errorf(format string, args ...interface{}) {
-	gcp.logger.Errorf(context.Background(), format, args)
+	gcp.logger.Error(context.Background(), format, args)
 }

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -117,6 +117,7 @@ func New(
 // provided, the consumer may call this function multiple times.
 func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) {
 	ctx := context.Background()
+	o.logger.With("node ID", req.GetNode().GetId()).With("type", req.GetTypeUrl()).Debug(ctx, "creating watch")
 
 	// If this is the first time we're seeing the request from the
 	// downstream client, initialize a channel to feed future responses.
@@ -258,6 +259,7 @@ func (o *orchestrator) watchUpstream(
 					o.logger.With("key", aggregatedKey).Error(ctx, "attempted to fan out with no cached response")
 				} else {
 					// Goldenpath.
+					o.logger.With("key", aggregatedKey).With("response", cached.Resp).Debug(ctx, "response fanout initiated")
 					o.fanout(cached.Resp, cached.Requests, aggregatedKey)
 				}
 			}
@@ -280,7 +282,8 @@ func (o *orchestrator) fanout(resp *cache.Response, watchers map[*gcp.Request]bo
 			if channel, ok := o.downstreamResponseMap.get(watch); ok {
 				select {
 				case channel <- convertToGcpResponse(resp, *watch):
-					break
+					o.logger.With("key", aggregatedKey).With("node ID", watch.GetNode().GetId()).
+						Debug(context.Background(), "response sent")
 				default:
 					// If the channel is blocked, we simply drop subsequent requests and error.
 					// Alternative possibilities are discussed here:

--- a/internal/app/server/server_test.go
+++ b/internal/app/server/server_test.go
@@ -47,6 +47,6 @@ func (l *logger) Warn(ctx context.Context, template string, args ...interface{})
 func (l *logger) Fatal(ctx context.Context, template string, args ...interface{}) {}
 func (l *logger) Panic(ctx context.Context, template string, args ...interface{}) {}
 func (l *logger) Error(ctx context.Context, template string, args ...interface{}) {
-	l.lastErr = fmt.Sprint(args...)
+	l.lastErr = fmt.Sprintf(template+"%v", args...)
 	l.blockedCh <- true
 }

--- a/internal/app/server/server_test.go
+++ b/internal/app/server/server_test.go
@@ -38,32 +38,26 @@ type logger struct {
 	lastErr   string
 }
 
-func (l *logger) Named(name string) log.Logger {
-	return l
-}
-
-func (l *logger) With(args ...interface{}) log.Logger {
-	return l
-}
-
-func (l *logger) Sync() error { return nil }
-
-func (l *logger) Debug(ctx context.Context, args ...interface{}) {
-}
-
-func (l *logger) Info(ctx context.Context, args ...interface{}) {
-}
-
-func (l *logger) Warn(ctx context.Context, args ...interface{}) {
-}
+func (l *logger) Named(name string) log.Logger                                     { return l }
+func (l *logger) With(args ...interface{}) log.Logger                              { return l }
+func (l *logger) Sync() error                                                      { return nil }
+func (l *logger) Debug(ctx context.Context, args ...interface{})                   {}
+func (l *logger) Info(ctx context.Context, args ...interface{})                    {}
+func (l *logger) Warn(ctx context.Context, args ...interface{})                    {}
+func (l *logger) Fatal(ctx context.Context, args ...interface{})                   {}
+func (l *logger) Panic(ctx context.Context, args ...interface{})                   {}
+func (l *logger) Debugf(ctx context.Context, template string, args ...interface{}) {}
+func (l *logger) Infof(ctx context.Context, template string, args ...interface{})  {}
+func (l *logger) Warnf(ctx context.Context, template string, args ...interface{})  {}
+func (l *logger) Fatalf(ctx context.Context, template string, args ...interface{}) {}
+func (l *logger) Panicf(ctx context.Context, template string, args ...interface{}) {}
 
 func (l *logger) Error(ctx context.Context, args ...interface{}) {
 	l.lastErr = fmt.Sprint(args...)
 	l.blockedCh <- true
 }
 
-func (l *logger) Fatal(ctx context.Context, args ...interface{}) {
-}
-
-func (l *logger) Panic(ctx context.Context, args ...interface{}) {
+func (l *logger) Errorf(ctx context.Context, template string, args ...interface{}) {
+	l.lastErr = fmt.Sprint(args...)
+	l.blockedCh <- true
 }

--- a/internal/app/server/server_test.go
+++ b/internal/app/server/server_test.go
@@ -38,26 +38,15 @@ type logger struct {
 	lastErr   string
 }
 
-func (l *logger) Named(name string) log.Logger                                     { return l }
-func (l *logger) With(args ...interface{}) log.Logger                              { return l }
-func (l *logger) Sync() error                                                      { return nil }
-func (l *logger) Debug(ctx context.Context, args ...interface{})                   {}
-func (l *logger) Info(ctx context.Context, args ...interface{})                    {}
-func (l *logger) Warn(ctx context.Context, args ...interface{})                    {}
-func (l *logger) Fatal(ctx context.Context, args ...interface{})                   {}
-func (l *logger) Panic(ctx context.Context, args ...interface{})                   {}
-func (l *logger) Debugf(ctx context.Context, template string, args ...interface{}) {}
-func (l *logger) Infof(ctx context.Context, template string, args ...interface{})  {}
-func (l *logger) Warnf(ctx context.Context, template string, args ...interface{})  {}
-func (l *logger) Fatalf(ctx context.Context, template string, args ...interface{}) {}
-func (l *logger) Panicf(ctx context.Context, template string, args ...interface{}) {}
-
-func (l *logger) Error(ctx context.Context, args ...interface{}) {
-	l.lastErr = fmt.Sprint(args...)
-	l.blockedCh <- true
-}
-
-func (l *logger) Errorf(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Named(name string) log.Logger                                    { return l }
+func (l *logger) With(args ...interface{}) log.Logger                             { return l }
+func (l *logger) Sync() error                                                     { return nil }
+func (l *logger) Debug(ctx context.Context, template string, args ...interface{}) {}
+func (l *logger) Info(ctx context.Context, template string, args ...interface{})  {}
+func (l *logger) Warn(ctx context.Context, template string, args ...interface{})  {}
+func (l *logger) Fatal(ctx context.Context, template string, args ...interface{}) {}
+func (l *logger) Panic(ctx context.Context, template string, args ...interface{}) {}
+func (l *logger) Error(ctx context.Context, template string, args ...interface{}) {
 	l.lastErr = fmt.Sprint(args...)
 	l.blockedCh <- true
 }

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -33,25 +33,49 @@ type Logger interface {
 	//  ).Info("this is an error message")
 	With(args ...interface{}) Logger
 
-	// Log a message at level Debug, annotated with fields provided through With().
+	// Debug logs a message at level Debug, annotated with fields provided through With().
 	Debug(ctx context.Context, msg ...interface{})
 
-	// Log a message at level Info, annotated with fields provided through With().
+	// Info logs a message at level Info, annotated with fields provided through With().
 	Info(ctx context.Context, msg ...interface{})
 
-	// Log a message at level Warn, annotated with fields provided through With().
+	// Warn logs a message at level Warn, annotated with fields provided through With().
 	Warn(ctx context.Context, msg ...interface{})
 
-	// Log a message at level Error, annotated with fields provided through With().
+	// Error logs a message at level Error, annotated with fields provided through With().
 	Error(ctx context.Context, msg ...interface{})
 
-	// Log a message at level Panic, annotated with fields provided through With(), and immediately
-	// panic.
+	// Panic logs a message at level Panic, annotated with fields provided through With(), and
+	// immediately panics.
 	Panic(ctx context.Context, msg ...interface{})
 
-	// Log a message at level Fatal, annotated with fields provided through With(), and immediately
-	// call os.Exit.
+	// Fatal logs a message at level Fatal, annotated with fields provided through With(), and
+	// immediately calls os.Exit.
 	Fatal(ctx context.Context, msg ...interface{})
+
+	// Debugf logs a message at level Debug with support for string formatting, annotated with
+	// fields provided through With().
+	Debugf(ctx context.Context, template string, msg ...interface{})
+
+	// Infof logs a message at level Info with support for string formatting, annotated with fields
+	// provided through With().
+	Infof(ctx context.Context, template string, msg ...interface{})
+
+	// Warnf logs a message at level Warn with support for string formatting, annotated with fields
+	// provided through With().
+	Warnf(ctx context.Context, template string, msg ...interface{})
+
+	// Errorf logs a message at level Error with support for string formatting, annotated with
+	// fields provided through With().
+	Errorf(ctx context.Context, template string, msg ...interface{})
+
+	// Panicf logs a message at level Panic with support for string formatting, annotated with
+	// fields provided through With(), and immediately panics.
+	Panicf(ctx context.Context, template string, msg ...interface{})
+
+	// Fatalf logs a message at level Fatal with support for string formatting, annotated with
+	// fields provided through With(), and immediately calls os.Exit.
+	Fatalf(ctx context.Context, template string, msg ...interface{})
 
 	// Sync flushes any buffered log entries.
 	Sync() error

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -33,49 +33,29 @@ type Logger interface {
 	//  ).Info("this is an error message")
 	With(args ...interface{}) Logger
 
-	// Debug logs a message at level Debug, annotated with fields provided through With().
-	Debug(ctx context.Context, msg ...interface{})
-
-	// Info logs a message at level Info, annotated with fields provided through With().
-	Info(ctx context.Context, msg ...interface{})
-
-	// Warn logs a message at level Warn, annotated with fields provided through With().
-	Warn(ctx context.Context, msg ...interface{})
-
-	// Error logs a message at level Error, annotated with fields provided through With().
-	Error(ctx context.Context, msg ...interface{})
-
-	// Panic logs a message at level Panic, annotated with fields provided through With(), and
-	// immediately panics.
-	Panic(ctx context.Context, msg ...interface{})
-
-	// Fatal logs a message at level Fatal, annotated with fields provided through With(), and
-	// immediately calls os.Exit.
-	Fatal(ctx context.Context, msg ...interface{})
-
-	// Debugf logs a message at level Debug with support for string formatting, annotated with
+	// Debug logs a message at level Debug with support for string formatting, annotated with
 	// fields provided through With().
-	Debugf(ctx context.Context, template string, msg ...interface{})
+	Debug(ctx context.Context, template string, msg ...interface{})
 
-	// Infof logs a message at level Info with support for string formatting, annotated with fields
+	// Info logs a message at level Info with support for string formatting, annotated with fields
 	// provided through With().
-	Infof(ctx context.Context, template string, msg ...interface{})
+	Info(ctx context.Context, template string, msg ...interface{})
 
-	// Warnf logs a message at level Warn with support for string formatting, annotated with fields
+	// Warn logs a message at level Warn with support for string formatting, annotated with fields
 	// provided through With().
-	Warnf(ctx context.Context, template string, msg ...interface{})
+	Warn(ctx context.Context, template string, msg ...interface{})
 
-	// Errorf logs a message at level Error with support for string formatting, annotated with
+	// Error logs a message at level Error with support for string formatting, annotated with
 	// fields provided through With().
-	Errorf(ctx context.Context, template string, msg ...interface{})
+	Error(ctx context.Context, template string, msg ...interface{})
 
-	// Panicf logs a message at level Panic with support for string formatting, annotated with
+	// Panic logs a message at level Panic with support for string formatting, annotated with
 	// fields provided through With(), and immediately panics.
-	Panicf(ctx context.Context, template string, msg ...interface{})
+	Panic(ctx context.Context, template string, msg ...interface{})
 
-	// Fatalf logs a message at level Fatal with support for string formatting, annotated with
+	// Fatal logs a message at level Fatal with support for string formatting, annotated with
 	// fields provided through With(), and immediately calls os.Exit.
-	Fatalf(ctx context.Context, template string, msg ...interface{})
+	Fatal(ctx context.Context, template string, msg ...interface{})
 
 	// Sync flushes any buffered log entries.
 	Sync() error

--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -70,3 +70,27 @@ func (l *logger) Fatal(ctx context.Context, args ...interface{}) {
 func (l *logger) Panic(ctx context.Context, args ...interface{}) {
 	l.WithContext(ctx).zap.Panic(args...)
 }
+
+func (l *logger) Debugf(ctx context.Context, template string, args ...interface{}) {
+	l.WithContext(ctx).zap.Debugf(template, args...)
+}
+
+func (l *logger) Infof(ctx context.Context, template string, args ...interface{}) {
+	l.WithContext(ctx).zap.Infof(template, args...)
+}
+
+func (l *logger) Warnf(ctx context.Context, template string, args ...interface{}) {
+	l.WithContext(ctx).zap.Warnf(template, args...)
+}
+
+func (l *logger) Errorf(ctx context.Context, template string, args ...interface{}) {
+	l.WithContext(ctx).zap.Errorf(template, args...)
+}
+
+func (l *logger) Fatalf(ctx context.Context, template string, args ...interface{}) {
+	l.WithContext(ctx).zap.Fatalf(template, args...)
+}
+
+func (l *logger) Panicf(ctx context.Context, template string, args ...interface{}) {
+	l.WithContext(ctx).zap.Panicf(template, args...)
+}

--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -47,50 +47,26 @@ func (l *logger) WithContext(ctx context.Context) *logger {
 
 func (l *logger) Sync() error { return l.zap.Sync() }
 
-func (l *logger) Debug(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Debug(args...)
-}
-
-func (l *logger) Info(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Info(args...)
-}
-
-func (l *logger) Warn(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Warn(args...)
-}
-
-func (l *logger) Error(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Error(args...)
-}
-
-func (l *logger) Fatal(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Fatal(args...)
-}
-
-func (l *logger) Panic(ctx context.Context, args ...interface{}) {
-	l.WithContext(ctx).zap.Panic(args...)
-}
-
-func (l *logger) Debugf(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Debug(ctx context.Context, template string, args ...interface{}) {
 	l.WithContext(ctx).zap.Debugf(template, args...)
 }
 
-func (l *logger) Infof(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Info(ctx context.Context, template string, args ...interface{}) {
 	l.WithContext(ctx).zap.Infof(template, args...)
 }
 
-func (l *logger) Warnf(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Warn(ctx context.Context, template string, args ...interface{}) {
 	l.WithContext(ctx).zap.Warnf(template, args...)
 }
 
-func (l *logger) Errorf(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Error(ctx context.Context, template string, args ...interface{}) {
 	l.WithContext(ctx).zap.Errorf(template, args...)
 }
 
-func (l *logger) Fatalf(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Fatal(ctx context.Context, template string, args ...interface{}) {
 	l.WithContext(ctx).zap.Fatalf(template, args...)
 }
 
-func (l *logger) Panicf(ctx context.Context, template string, args ...interface{}) {
+func (l *logger) Panic(ctx context.Context, template string, args ...interface{}) {
 	l.WithContext(ctx).zap.Panicf(template, args...)
 }


### PR DESCRIPTION
Equivalent to `fmt.Sprintf`. Support templated logging. This is
especially important when passing the logger to go-control-plane in
certain packages, such as e2e tests.

Without this change we will continue to see log messages like the
following:
```
open watch +%v, %d, ...
```

Also
* Add debug and info logs to orchestrator
* Default to debug logs for e2e tests

Signed-off-by: Jess Yuen <jyuen@lyft.com>