### PR TITLE
Retry integration tests up to 3 times

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches:
       - master
-env:
-  PACKAGEPATH: ${{ github.workspace }}/go/src/github.com/${{ github.repository }}
 jobs:
   tests:
     strategy:
@@ -18,18 +16,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          path: ${{ env.PACKAGEPATH }}
       - name: Install Go
         uses: actions/setup-go@v2-beta
         with:
           go-version: ${{ matrix.go-version }}
       - name: Build xds-relay binary
         run: make compile
-        working-directory: ${{ env.PACKAGEPATH }}
       - name: Build configuration validator tool
         run: make compile-validator-tool
-        working-directory: ${{ env.PACKAGEPATH }}
       - name: Run integration tests
-        run: make integration-tests
-        working-directory: ${{ env.PACKAGEPATH }}
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: make integration-tests

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -34,3 +34,7 @@ func TestServerShutdown(t *testing.T) {
 	err = cmd.Wait()
 	assert.Nil(t, e)
 }
+
+func TestAssertAlwaysFalse(t *testing.T) {
+	assert.Equal(t, 1, 2)
+}

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -34,7 +34,3 @@ func TestServerShutdown(t *testing.T) {
 	err = cmd.Wait()
 	assert.Nil(t, e)
 }
-
-func TestAssertAlwaysFalse(t *testing.T) {
-	assert.Equal(t, 1, 2)
-}


### PR DESCRIPTION
We retry the integration tests up to 3 times using https://github.com/marketplace/actions/retry-step.

This is a stopgap until we find out a better solution to solve issue described in https://github.com/envoyproxy/xds-relay/issues/84#issuecomment-628852414.

I'm adding the failing test just to confirm the retries actually happen.

Signed-off-by: eapolinario <eapolinario@lyft.com>