### PR TITLE
Unmarshal v2 resources in cache_dump

### DIFF
--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -143,12 +143,13 @@ type marshalledDiscoveryResponse struct {
 }
 
 type xDSResources struct {
-	Endpoints []*v2.ClusterLoadAssignment
-	Clusters  []*v2.Cluster
-	Routes    []*v2.RouteConfiguration
-	Listeners []*v2.Listener
-	Secrets   []*envoy_api_v2_auth.Secret
-	Runtimes  []*envoy_service_discovery_v2.Runtime
+	Endpoints    []*v2.ClusterLoadAssignment
+	Clusters     []*v2.Cluster
+	Routes       []*v2.RouteConfiguration
+	Listeners    []*v2.Listener
+	Secrets      []*envoy_api_v2_auth.Secret
+	Runtimes     []*envoy_service_discovery_v2.Runtime
+	Unmarshalled []*any.Any
 }
 
 func marshalDiscoveryResponse(resp *v2.DiscoveryResponse) *marshalledDiscoveryResponse {
@@ -175,38 +176,51 @@ func marshalResources(Resources []*any.Any) *xDSResources {
 			err := ptypes.UnmarshalAny(resource, e)
 			if err == nil {
 				marshalledResources.Endpoints = append(marshalledResources.Endpoints, e)
+			} else {
+				marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 			}
 		case resource2.ClusterType:
 			c := &v2.Cluster{}
 			err := ptypes.UnmarshalAny(resource, c)
 			if err == nil {
 				marshalledResources.Clusters = append(marshalledResources.Clusters, c)
+			} else {
+				marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 			}
 		case resource2.RouteType:
 			r := &v2.RouteConfiguration{}
 			err := ptypes.UnmarshalAny(resource, r)
 			if err == nil {
 				marshalledResources.Routes = append(marshalledResources.Routes, r)
+			} else {
+				marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 			}
 		case resource2.ListenerType:
 			l := &v2.Listener{}
 			err := ptypes.UnmarshalAny(resource, l)
 			if err == nil {
 				marshalledResources.Listeners = append(marshalledResources.Listeners, l)
+			} else {
+				marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 			}
 		case resource2.SecretType:
 			s := &envoy_api_v2_auth.Secret{}
 			err := ptypes.UnmarshalAny(resource, s)
 			if err == nil {
 				marshalledResources.Secrets = append(marshalledResources.Secrets, s)
+			} else {
+				marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 			}
 		case resource2.RuntimeType:
 			r := &envoy_service_discovery_v2.Runtime{}
 			err := ptypes.UnmarshalAny(resource, r)
 			if err == nil {
 				marshalledResources.Runtimes = append(marshalledResources.Runtimes, r)
+			} else {
+				marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 			}
 		default:
+			marshalledResources.Unmarshalled = append(marshalledResources.Unmarshalled, resource)
 		}
 	}
 	return &marshalledResources

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 	"time"
 
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+
+	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoy_service_discovery_v2 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
+	resource2 "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/any"
+
 	"github.com/envoyproxy/xds-relay/internal/pkg/util/stringify"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -102,7 +110,7 @@ func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 }
 
 type marshallableResource struct {
-	Resp           *v2.DiscoveryResponse
+	Resp           *marshalledDiscoveryResponse
 	Requests       []*v2.DiscoveryRequest
 	ExpirationTime time.Time
 }
@@ -110,7 +118,6 @@ type marshallableResource struct {
 // In order to marshal a Resource from the cache to JSON to be printed,
 // the map of requests is converted to a slice of just the keys,
 // since the bool value is meaningless.
-// TODO(lisalu): More intelligent unmarshalling of DiscoveryResponse.
 func resourceToString(resource cache.Resource) (string, error) {
 	var requests []*v2.DiscoveryRequest
 	for request := range resource.Requests {
@@ -118,12 +125,91 @@ func resourceToString(resource cache.Resource) (string, error) {
 	}
 
 	resourceString := &marshallableResource{
-		Resp:           resource.Resp,
+		Resp:           marshalDiscoveryResponse(resource.Resp),
 		Requests:       requests,
 		ExpirationTime: resource.ExpirationTime,
 	}
 
 	return stringify.InterfaceToString(resourceString)
+}
+
+type marshalledDiscoveryResponse struct {
+	VersionInfo  string
+	Resources    *xDSResources
+	Canary       bool
+	TypeURL      string
+	Nonce        string
+	ControlPlane *envoy_api_v2_core.ControlPlane
+}
+
+type xDSResources struct {
+	Endpoints []*v2.ClusterLoadAssignment
+	Clusters  []*v2.Cluster
+	Routes    []*v2.RouteConfiguration
+	Listeners []*v2.Listener
+	Secrets   []*envoy_api_v2_auth.Secret
+	Runtimes  []*envoy_service_discovery_v2.Runtime
+}
+
+func marshalDiscoveryResponse(resp *v2.DiscoveryResponse) *marshalledDiscoveryResponse {
+	if resp != nil {
+		marshalledResp := marshalledDiscoveryResponse{
+			VersionInfo:  resp.VersionInfo,
+			Canary:       resp.Canary,
+			TypeURL:      resp.TypeUrl,
+			Resources:    marshalResources(resp.Resources),
+			Nonce:        resp.Nonce,
+			ControlPlane: resp.ControlPlane,
+		}
+		return &marshalledResp
+	}
+	return nil
+}
+
+func marshalResources(Resources []*any.Any) *xDSResources {
+	var marshalledResources xDSResources
+	for _, resource := range Resources {
+		switch resource.TypeUrl {
+		case resource2.EndpointType:
+			e := &v2.ClusterLoadAssignment{}
+			err := ptypes.UnmarshalAny(resource, e)
+			if err == nil {
+				marshalledResources.Endpoints = append(marshalledResources.Endpoints, e)
+			}
+		case resource2.ClusterType:
+			c := &v2.Cluster{}
+			err := ptypes.UnmarshalAny(resource, c)
+			if err == nil {
+				marshalledResources.Clusters = append(marshalledResources.Clusters, c)
+			}
+		case resource2.RouteType:
+			r := &v2.RouteConfiguration{}
+			err := ptypes.UnmarshalAny(resource, r)
+			if err == nil {
+				marshalledResources.Routes = append(marshalledResources.Routes, r)
+			}
+		case resource2.ListenerType:
+			l := &v2.Listener{}
+			err := ptypes.UnmarshalAny(resource, l)
+			if err == nil {
+				marshalledResources.Listeners = append(marshalledResources.Listeners, l)
+			}
+		case resource2.SecretType:
+			s := &envoy_api_v2_auth.Secret{}
+			err := ptypes.UnmarshalAny(resource, s)
+			if err == nil {
+				marshalledResources.Secrets = append(marshalledResources.Secrets, s)
+			}
+		case resource2.RuntimeType:
+			r := &envoy_service_discovery_v2.Runtime{}
+			err := ptypes.UnmarshalAny(resource, r)
+			if err == nil {
+				marshalledResources.Runtimes = append(marshalledResources.Runtimes, r)
+			}
+		default:
+		}
+	}
+	return &marshalledResources
 }
 
 func getCacheKeyParam(path string) (string, error) {

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/envoyproxy/xds-relay/internal/app/mapper"
 	"github.com/envoyproxy/xds-relay/internal/app/orchestrator"
-
+	"github.com/golang/protobuf/ptypes"
 	"github.com/uber-go/tally"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -98,18 +98,26 @@ func TestAdminServer_CacheDumpHandler(t *testing.T) {
 	gcpReq := gcp.Request{
 		TypeUrl: "type.googleapis.com/envoy.api.v2.Listener",
 	}
-	_, _ = orchestrator.CreateWatch(gcpReq)
+	respChannel, cancelWatch := orchestrator.CreateWatch(gcpReq)
+	assert.NotNil(t, respChannel)
 
+	listener := &v2.Listener{
+		Name: "lds resource",
+	}
+	listenerAny, err := ptypes.MarshalAny(listener)
+	assert.NoError(t, err)
 	resp := v2.DiscoveryResponse{
 		VersionInfo: "1",
 		TypeUrl:     "type.googleapis.com/envoy.api.v2.Listener",
 		Resources: []*any.Any{
-			{
-				Value: []byte("lds resource"),
-			},
+			listenerAny,
 		},
 	}
 	upstreamResponseChannel <- &resp
+	gotResponse := <-respChannel
+	gotDiscoveryResponse, err := gotResponse.GetDiscoveryResponse()
+	assert.NoError(t, err)
+	assert.Equal(t, resp, *gotDiscoveryResponse)
 
 	req, err := http.NewRequest("GET", "/cache/lds", nil)
 	assert.NoError(t, err)
@@ -121,13 +129,23 @@ func TestAdminServer_CacheDumpHandler(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), `{
   "Resp": {
-    "version_info": "1",
-    "resources": [
-      {
-        "value": "bGRzIHJlc291cmNl"
-      }
-    ],
-    "type_url": "type.googleapis.com/envoy.api.v2.Listener"
+    "VersionInfo": "1",
+    "Resources": {
+      "Endpoints": null,
+      "Clusters": null,
+      "Routes": null,
+      "Listeners": [
+        {
+          "name": "lds resource"
+        }
+      ],
+      "Secrets": null,
+      "Runtimes": null
+    },
+    "Canary": false,
+    "TypeURL": "type.googleapis.com/envoy.api.v2.Listener",
+    "Nonce": "",
+    "ControlPlane": null
   },
   "Requests": [
     {
@@ -135,6 +153,7 @@ func TestAdminServer_CacheDumpHandler(t *testing.T) {
     }
   ],
   "ExpirationTime": "`)
+	cancelWatch()
 }
 
 func TestAdminServer_CacheDumpHandler_NotFound(t *testing.T) {
@@ -175,4 +194,38 @@ func TestGetCacheKeyParam_Malformed(t *testing.T) {
 	cacheKey, err := getCacheKeyParam(path)
 	assert.Error(t, err, "")
 	assert.Equal(t, "", cacheKey)
+}
+
+func TestMarshalResources(t *testing.T) {
+	listener := &v2.Listener{
+		Name: "lds resource",
+	}
+	listenerAny, err := ptypes.MarshalAny(listener)
+	assert.NoError(t, err)
+	marshalled := marshalResources([]*any.Any{
+		listenerAny,
+	})
+	assert.NotNil(t, marshalled)
+	assert.Equal(t, 1, len(marshalled.Listeners))
+	assert.Equal(t, "lds resource", marshalled.Listeners[0].Name)
+}
+
+func TestMarshalDiscoveryResponse(t *testing.T) {
+	listener := &v2.Listener{
+		Name: "lds resource",
+	}
+	listenerAny, err := ptypes.MarshalAny(listener)
+	assert.NoError(t, err)
+	resp := v2.DiscoveryResponse{
+		VersionInfo: "1",
+		TypeUrl:     "type.googleapis.com/envoy.api.v2.Listener",
+		Resources: []*any.Any{
+			listenerAny,
+		},
+	}
+	marshalled := marshalDiscoveryResponse(&resp)
+	assert.NotNil(t, marshalled)
+	assert.Equal(t, resp.VersionInfo, marshalled.VersionInfo)
+	assert.Equal(t, resp.TypeUrl, marshalled.TypeURL)
+	assert.Equal(t, listener.Name, marshalled.Resources.Listeners[0].Name)
 }

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -140,7 +140,8 @@ func TestAdminServer_CacheDumpHandler(t *testing.T) {
         }
       ],
       "Secrets": null,
-      "Runtimes": null
+      "Runtimes": null,
+      "Unmarshalled": null
     },
     "Canary": false,
     "TypeURL": "type.googleapis.com/envoy.api.v2.Listener",


### PR DESCRIPTION
This change unmarshals xDS resources in the cache from the generic Any form based on the TypeURL, utilizing the same logic as https://github.com/envoyproxy/go-control-plane/blob/e933a9f2ccd2c350a7d7c67317fceb79b3cd8ff6/pkg/cache/v2/resource.go#L52. This change only unmarshals V2 resources. Resources whose type URLs do not match are included in the output under the `Unmarshalled` field. Addresses #93.

Example output:
```
{
  "Resp": {
    "VersionInfo": "1",
    "Resources": {
      "Endpoints": null,
      "Clusters": null,
      "Routes": null,
      "Listeners": [
        {
          "name": "lds resource"
        }
      ],
      "Secrets": null,
      "Runtimes": null,
      "Unmarshalled": null
    },
    "Canary": false,
    "TypeURL": "type.googleapis.com/envoy.api.v2.Listener",
    "Nonce": "",
    "ControlPlane": null
  },
  "Requests": [
    {
      "type_url": "type.googleapis.com/envoy.api.v2.Listener"
    }
  ],
  "ExpirationTime": "2020-06-16T10:45:46.703325-07:00"
}
```
