### PR TITLE
Add json namespace for service fields

### DIFF
--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -33,6 +33,8 @@ func New(logLevel string, writeTo io.Writer) Logger {
 		// Log an invalid log level error and set the default level to info.
 		log.Error("cannot set logger to desired log level")
 	}
+
+	log = log.With(z.Namespace("json"))
 	return &logger{zap: log.Sugar(), writeTo: writeTo}
 }
 
@@ -54,6 +56,7 @@ func (l *logger) UpdateLogLevel(logLevel string) {
 		log.Error("cannot set logger to desired log level")
 	}
 
+	log = log.With(z.Namespace("json"))
 	l.zap = log.Sugar()
 }
 


### PR DESCRIPTION
This change puts xdsrelay-specific fields under one key `json`. We can later make this value configurable or optional.

example log:

`{"level":"debug","ts":1594750385.907022,"logger":"upstream_client","msg":"received message","json":{"response_version":"v0","response_type":"type.googleapis.com/envoy.api.v2.Cluster","resource_length":2}}`