### PR TITLE
Fix comment on default log output

### DIFF
--- a/api/protos/bootstrap/v1/bootstrap.proto
+++ b/api/protos/bootstrap/v1/bootstrap.proto
@@ -43,7 +43,7 @@ message Upstream {
 
 // [#next-free-field: 3]
 message Logging {
-    // Filepath where logs are emitted. If no filepath is specified, logs will be written to `/dev/null`.
+    // Filepath where logs are emitted. If no filepath is specified, logs will be written to stderr.
     string path = 1;
 
     // The logging level. If no logging level is set, the default is INFO.

--- a/pkg/api/bootstrap/v1/bootstrap.pb.go
+++ b/pkg/api/bootstrap/v1/bootstrap.pb.go
@@ -279,7 +279,7 @@ type Logging struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Filepath where logs are emitted. If no filepath is specified, logs will be written to `/dev/null`.
+	// Filepath where logs are emitted. If no filepath is specified, logs will be written to stderr.
 	Path  string        `protobuf:"bytes,1,opt,name=path,proto3" json:"path,omitempty"`
 	Level Logging_Level `protobuf:"varint,2,opt,name=level,proto3,enum=bootstrap.Logging_Level" json:"level,omitempty"`
 }


### PR DESCRIPTION
We actually set the default log output to STDERR here:
https://github.com/envoyproxy/xds-relay/blob/master/internal/app/server/server.go#L54-L56

This is also consistent with the zap default: https://godoc.org/sigs.k8s.io/controller-runtime/pkg/log/zap#WriteTo.