### PR TITLE
Fix flaky unit test

### DIFF
--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -156,8 +156,6 @@ func TestGoldenPath(t *testing.T) {
 
 	gotResponse := <-respChannel
 	assertEqualResponse(t, gotResponse, resp, req)
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.fanout", aggregatedKey), 1)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -165,6 +163,9 @@ func TestGoldenPath(t *testing.T) {
 	testutils.AssertSyncMapLen(t, 0, orchestrator.upstreamResponseMap.internal)
 
 	cancelWatch()
+
+	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
+		fmt.Sprintf("mock_orchestrator.%s.watch.fanout", aggregatedKey), 1)
 	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
 		fmt.Sprintf("mock_orchestrator.%s.watch.canceled", aggregatedKey), 1)
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))


### PR DESCRIPTION
Assert stats only after watches have been cleaned up. This prevents a
flaky case where we check that the stat has been incremented before
the codepath is executed.

Signed-off-by: Jess Yuen <jyuen@lyft.com>