### PR TITLE
Add Error Interceptor

### DIFF
--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -89,9 +89,9 @@ const (
 	MapperError   = "error"   // counter, # of errors when converting a request to an aggregated key
 )
 
-// .error_interceptor
+// .upstream.error_interceptor
 const (
-	// scope: .error_interceptor.*
+	// scope: .upstream.error_interceptor.*
 	ScopeErrorInterceptor = "error_interceptor"
 
 	ErrorInterceptorErrorSendMsg = "error_sendmsg"

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -89,6 +89,15 @@ const (
 	MapperError   = "error"   // counter, # of errors when converting a request to an aggregated key
 )
 
+// .error_interceptor
+const (
+	// scope: .error_interceptor.*
+	ScopeErrorInterceptor = "error_interceptor"
+
+	ErrorInterceptorErrorSendMsg = "error_sendmsg"
+	ErrorInterceptorErrorRecvMsg = "error_recvmsg"
+)
+
 // OrchestratorWatchSubscope gets the orchestor watch subscope for the aggregated key.
 // ex: .orchestrator.$aggregated_key.watch
 func OrchestratorWatchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -94,7 +94,8 @@ func New(
 	namedLogger.With("address", url).Info(ctx, "Initiating upstream connection")
 	subScope := scope.SubScope(metrics.ScopeUpstream)
 	// TODO: configure grpc options.https://github.com/envoyproxy/xds-relay/issues/55
-	conn, err := grpc.Dial(url, grpc.WithInsecure(), grpc.WithStreamInterceptor(ErrorClientStreamInterceptor(namedLogger, subScope)))
+	conn, err := grpc.Dial(url, grpc.WithInsecure(),
+		grpc.WithStreamInterceptor(ErrorClientStreamInterceptor(namedLogger, subScope)))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -92,8 +92,9 @@ func New(
 ) (Client, error) {
 	namedLogger := logger.Named("upstream_client")
 	namedLogger.With("address", url).Info(ctx, "Initiating upstream connection")
+	subScope := scope.SubScope(metrics.ScopeUpstream)
 	// TODO: configure grpc options.https://github.com/envoyproxy/xds-relay/issues/55
-	conn, err := grpc.Dial(url, grpc.WithInsecure())
+	conn, err := grpc.Dial(url, grpc.WithInsecure(), grpc.WithStreamInterceptor(ErrorClientStreamInterceptor(namedLogger, subScope)))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +113,7 @@ func New(
 		cdsClient:   cdsClient,
 		callOptions: callOptions,
 		logger:      namedLogger,
-		scope:       scope.SubScope(metrics.ScopeUpstream),
+		scope:       subScope,
 	}, nil
 }
 

--- a/internal/app/upstream/error_interceptor.go
+++ b/internal/app/upstream/error_interceptor.go
@@ -1,0 +1,58 @@
+package upstream
+
+import (
+	"context"
+
+	"github.com/envoyproxy/xds-relay/internal/app/metrics"
+	"github.com/envoyproxy/xds-relay/internal/pkg/log"
+	"github.com/uber-go/tally"
+	"google.golang.org/grpc"
+)
+
+func ErrorClientStreamInterceptor(logger log.Logger, scope tally.Scope) grpc.StreamClientInterceptor {
+	return func(ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			return nil, err
+		}
+		stream := &wrappedStream{
+			clientStream,
+			ctx,
+			logger.Named("error_interceptor"),
+			scope.SubScope(metrics.ScopeErrorInterceptor),
+		}
+		return stream, nil
+	}
+}
+
+// wrappedStream wraps around the grpc.CientStream used to send and receive messages,
+// intercepting those calls and logging in case an error is encountered.
+type wrappedStream struct {
+	grpc.ClientStream
+	ctx    context.Context
+	logger log.Logger
+	scope  tally.Scope
+}
+
+func (w *wrappedStream) RecvMsg(m interface{}) error {
+	err := w.ClientStream.RecvMsg(m)
+	if err != nil {
+		w.logger.With("message", m).Warn(w.ctx, "error in RecvMsg")
+		w.scope.Counter(metrics.ErrorInterceptorErrorRecvMsg).Inc(1)
+	}
+	return err
+}
+
+func (w *wrappedStream) SendMsg(m interface{}) error {
+	err := w.ClientStream.SendMsg(m)
+	if err != nil {
+		w.logger.With("message", m).Warn(w.ctx, "error in SendMsg")
+		w.scope.Counter(metrics.ErrorInterceptorErrorSendMsg).Inc(1)
+	}
+	return err
+}


### PR DESCRIPTION
This PR adds a [`StreamClientInterceptor`](https://github.com/grpc/grpc-go/tree/master/examples/features/interceptor#stream-interceptor) that records whenever there's an error in either `SendMsg` or `RecvMsg` functions in any of the calls in the bidi streams present in the upstream client.

Signed-off-by: eapolinario <eapolinario@lyft.com>