### PR TITLE
Explicitly close downstream watches

### DIFF
--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -27,7 +27,7 @@ const (
 	// scope: .orchestrator.$aggregated_key.cache_evict.*
 	ScopeOrchestratorCacheEvict            = "cache_evict"
 	OrcheestratorCacheEvictCount           = "calls"            // counter, # of times cache evict is called
-	OrchestratorOnCacheEvictedRequestCount = "requests_evicted" // counter, # of requests that were evicted for this aggregated key.
+	OrchestratorOnCacheEvictedRequestCount = "requests_evicted" // counter, # of requests that were evicted
 
 	// scope: .orchestrator.$aggregated_key.watch.errors.*
 	ScopeOrchestratorWatchErrors = "errors"

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -20,10 +20,14 @@ const (
 
 	// scope: .orchestrator.$aggregated_key.watch.*
 	ScopeOrchestratorWatch    = "watch"
-	OrchestratorWatchCreated  = "created"     // counter, # of watches created per aggregated key
-	OrchestratorWatchCanceled = "canceled"    // counter, # of watch cancels initiated per aggregated key
-	OrchestratorWatchFanouts  = "fanout"      // counter, # of responses pushed downstream
-	OrchestratorOnCacheEvict  = "cache_evict" // counter, # of times cache evict is called
+	OrchestratorWatchCreated  = "created"  // counter, # of watches created per aggregated key
+	OrchestratorWatchCanceled = "canceled" // counter, # of watch cancels initiated per aggregated key
+	OrchestratorWatchFanouts  = "fanout"   // counter, # of responses pushed downstream
+
+	// scope: .orchestrator.$aggregated_key.cache_evict.*
+	ScopeOrchestratorCacheEvict            = "cache_evict"
+	OrcheestratorCacheEvictCount           = "calls"            // counter, # of times cache evict is called
+	OrchestratorOnCacheEvictedRequestCount = "requests_evicted" // counter, # of requests that were evicted for this aggregated key.
 
 	// scope: .orchestrator.$aggregated_key.watch.errors.*
 	ScopeOrchestratorWatchErrors = "errors"
@@ -109,6 +113,12 @@ func OrchestratorWatchSubscope(parent tally.Scope, aggregatedKey string) tally.S
 // ex: .orchestrator.$aggregated_key.watch.errors
 func OrchestratorWatchErrorsSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorWatch).SubScope(ScopeOrchestratorWatchErrors)
+}
+
+// OrchestratorCacheEvictSubscope gets the orchestor cache evict subscope for the aggregated key.
+// ex: .orchestrator.$aggregated_key.cache_evict
+func OrchestratorCacheEvictSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
+	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorCacheEvict)
 }
 
 // CacheFetchSubscope gets the cache fetch subscope for the aggregated key.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -20,9 +20,10 @@ const (
 
 	// scope: .orchestrator.$aggregated_key.watch.*
 	ScopeOrchestratorWatch    = "watch"
-	OrchestratorWatchCreated  = "created"  // counter, # of watches created per aggregated key
-	OrchestratorWatchCanceled = "canceled" // counter, # of watch cancels initiated per aggregated key
-	OrchestratorWatchFanouts  = "fanout"   // counter, # of responses pushed downstream
+	OrchestratorWatchCreated  = "created"     // counter, # of watches created per aggregated key
+	OrchestratorWatchCanceled = "canceled"    // counter, # of watch cancels initiated per aggregated key
+	OrchestratorWatchFanouts  = "fanout"      // counter, # of responses pushed downstream
+	OrchestratorOnCacheEvict  = "cache_evict" // counter, # of times cache evict is called
 
 	// scope: .orchestrator.$aggregated_key.watch.errors.*
 	ScopeOrchestratorWatchErrors = "errors"

--- a/internal/app/orchestrator/downstream.go
+++ b/internal/app/orchestrator/downstream.go
@@ -12,6 +12,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/envoyproxy/xds-relay/internal/app/mapper"
@@ -19,32 +20,42 @@ import (
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
+// responseChannel stores the responses to be sent to downstream clients. A
+// WaitGroup is used here to ensure that all writes to the channel are
+// processed before we attempt to close the channel.
+type responseChannel struct {
+	wg      sync.WaitGroup
+	channel chan gcp.Response
+}
+
 // downstreamResponseMap is a map of downstream xDS client requests to response
 // channels.
 type downstreamResponseMap struct {
 	mu               sync.RWMutex
-	responseChannels map[*gcp.Request]chan gcp.Response
+	responseChannels map[*gcp.Request]*responseChannel
 }
 
 func newDownstreamResponseMap() downstreamResponseMap {
 	return downstreamResponseMap{
-		responseChannels: make(map[*gcp.Request]chan gcp.Response),
+		responseChannels: make(map[*gcp.Request]*responseChannel),
 	}
 }
 
 // createChannel initializes a new channel for a request if it doesn't already
 // exist.
-func (d *downstreamResponseMap) createChannel(req *gcp.Request) chan gcp.Response {
+func (d *downstreamResponseMap) createChannel(req *gcp.Request) *responseChannel {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, ok := d.responseChannels[req]; !ok {
-		d.responseChannels[req] = make(chan gcp.Response, 1)
+		d.responseChannels[req] = &responseChannel{
+			channel: make(chan gcp.Response, 1),
+		}
 	}
 	return d.responseChannels[req]
 }
 
 // get retrieves the channel where responses are set for the specified request.
-func (d *downstreamResponseMap) get(req *gcp.Request) (chan gcp.Response, bool) {
+func (d *downstreamResponseMap) get(req *gcp.Request) (*responseChannel, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	channel, ok := d.responseChannels[req]
@@ -56,10 +67,12 @@ func (d *downstreamResponseMap) get(req *gcp.Request) (chan gcp.Response, bool) 
 func (d *downstreamResponseMap) delete(req *gcp.Request) chan gcp.Response {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if channel, ok := d.responseChannels[req]; ok {
-		close(channel)
+	if responseChannel, ok := d.responseChannels[req]; ok {
+		// wait for all writes to the responseChannel to complete before closing.
+		responseChannel.wg.Wait()
+		close(responseChannel.channel)
 		delete(d.responseChannels, req)
-		return channel
+		return responseChannel.channel
 	}
 	return nil
 }
@@ -70,8 +83,10 @@ func (d *downstreamResponseMap) deleteAll(watchers map[*gcp.Request]bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	for watch := range watchers {
-		if channel, ok := d.responseChannels[watch]; ok {
-			close(channel)
+		if responseChannel, ok := d.responseChannels[watch]; ok {
+			// wait for all writes to the responseChannel to complete before closing.
+			responseChannel.wg.Wait()
+			close(responseChannel.channel)
 			delete(d.responseChannels, watch)
 		}
 	}
@@ -91,4 +106,15 @@ func (d *downstreamResponseMap) getAggregatedKeys(m *mapper.Mapper) (map[string]
 		keys[key] = true
 	}
 	return keys, nil
+}
+
+func (responseChannel *responseChannel) addResponse(resp gcp.PassthroughResponse) error {
+	responseChannel.wg.Add(1)
+	defer responseChannel.wg.Done()
+	select {
+	case responseChannel.channel <- resp:
+		return nil
+	default:
+		return fmt.Errorf("channel is blocked")
+	}
 }

--- a/internal/app/orchestrator/downstream_test.go
+++ b/internal/app/orchestrator/downstream_test.go
@@ -1,0 +1,94 @@
+// Package orchestrator is responsible for instrumenting inbound xDS client
+// requests to the correct aggregated key, forwarding a representative request
+// to the upstream origin server, and managing the lifecycle of downstream and
+// upstream connections and associates streams. It implements
+// go-control-plane's Cache interface in order to receive xDS-based requests,
+// send responses, and handle gRPC streams.
+//
+// This file manages the bookkeeping of downstream clients by tracking inbound
+// requests to their corresponding response channels. The contents of this file
+// are intended to only be used within the orchestrator module and should not
+// be exported.
+package orchestrator
+
+import (
+	"testing"
+
+	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	mockRequest = gcp.Request{
+		TypeUrl: "type.googleapis.com/envoy.api.v2.Listener",
+	}
+)
+
+func Test_downstreamResponseMap_createChannel(t *testing.T) {
+	responseMap := newDownstreamResponseMap()
+	assert.Equal(t, 0, len(responseMap.responseChannels))
+	responseMap.createChannel(&mockRequest)
+	assert.Equal(t, 1, len(responseMap.responseChannels))
+}
+
+func Test_downstreamResponseMap_get(t *testing.T) {
+	responseMap := newDownstreamResponseMap()
+	request := &mockRequest
+	responseMap.createChannel(request)
+	assert.Equal(t, 1, len(responseMap.responseChannels))
+	if _, ok := responseMap.get(request); !ok {
+		t.Error("request not found")
+	}
+}
+
+func Test_downstreamResponseMap_delete(t *testing.T) {
+	responseMap := newDownstreamResponseMap()
+	request := &mockRequest
+	request2 := &gcp.Request{
+		TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
+	}
+	responseMap.createChannel(request)
+	responseMap.createChannel(request2)
+	assert.Equal(t, 2, len(responseMap.responseChannels))
+	if _, ok := responseMap.get(request); !ok {
+		t.Error("request not found")
+	}
+	if _, ok := responseMap.get(request2); !ok {
+		t.Error("request not found")
+	}
+	responseMap.delete(request)
+	assert.Equal(t, 1, len(responseMap.responseChannels))
+	if _, ok := responseMap.get(request); ok {
+		t.Error("request found, when should be deleted")
+	}
+	responseMap.delete(request2)
+	assert.Equal(t, 0, len(responseMap.responseChannels))
+}
+
+func Test_downstreamResponseMap_deleteAll(t *testing.T) {
+	responseMap := newDownstreamResponseMap()
+	request := &mockRequest
+	request2 := &gcp.Request{
+		TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
+	}
+	request3 := &gcp.Request{
+		TypeUrl: "type.googleapis.com/envoy.api.v2.RouteConfiguration",
+	}
+	responseMap.createChannel(request)
+	responseMap.createChannel(request2)
+	responseMap.createChannel(request3)
+	assert.Equal(t, 3, len(responseMap.responseChannels))
+	responseMap.deleteAll(
+		map[*gcp.Request]bool{
+			request:  true,
+			request2: true,
+		},
+	)
+	assert.Equal(t, 1, len(responseMap.responseChannels))
+	if _, ok := responseMap.get(request); ok {
+		t.Error("request found, when should be deleted")
+	}
+	if _, ok := responseMap.get(request2); ok {
+		t.Error("request found, when should be deleted")
+	}
+}

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -177,7 +177,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		// If we have a cached response and the version is different,
 		// immediately push the result to the response channel.
 		go func() {
-			responseChannel <- convertToGcpResponse(cached.Resp, req)
+			responseChannel.addResponse(convertToGcpResponse(cached.Resp, req))
 			metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchFanouts).Inc(1)
 		}()
 	}
@@ -210,7 +210,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		}
 	}
 
-	return responseChannel, o.onCancelWatch(aggregatedKey, &req)
+	return responseChannel.channel, o.onCancelWatch(aggregatedKey, &req)
 }
 
 // Fetch implements the polling method of the config cache using a non-empty request.
@@ -329,23 +329,22 @@ func (o *orchestrator) fanout(resp *discovery.DiscoveryResponse, watchers map[*g
 		go func(watch *gcp.Request) {
 			defer wg.Done()
 			if channel, ok := o.downstreamResponseMap.get(watch); ok {
-				select {
-				case channel <- convertToGcpResponse(resp, *watch):
-					o.logger.With(
-						"aggregated_key", aggregatedKey,
-						"node_id", watch.GetNode().GetId(),
-						"response_version", resp.GetVersionInfo(),
-						"response_type", resp.GetTypeUrl(),
-					).Debug(context.Background(), "response sent")
-					metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchFanouts).Inc(1)
-				default:
+				if err := channel.addResponse(convertToGcpResponse(resp, *watch)); err != nil {
 					// If the channel is blocked, we simply drop subsequent requests and error.
 					// Alternative possibilities are discussed here:
 					// https://github.com/envoyproxy/xds-relay/pull/53#discussion_r420325553
 					o.logger.With("aggregated_key", aggregatedKey).With("node_id", watch.GetNode().GetId()).
 						Error(context.Background(), "channel blocked during fanout")
 					metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorChannelFull).Inc(1)
+					return
 				}
+				o.logger.With(
+					"aggregated_key", aggregatedKey,
+					"node_id", watch.GetNode().GetId(),
+					"response_version", resp.GetVersionInfo(),
+					"response_type", resp.GetTypeUrl(),
+				).Debug(context.Background(), "response sent")
+				metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchFanouts).Inc(1)
 			}
 		}(watch)
 	}

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -370,7 +370,8 @@ func (o *orchestrator) onCacheEvicted(key string, resource cache.Resource) {
 	// TODO Potential for improvements here to handle the thundering herd
 	// problem: https://github.com/envoyproxy/xds-relay/issues/71
 	metrics.OrchestratorCacheEvictSubscope(o.scope, key).Counter(metrics.OrcheestratorCacheEvictCount).Inc(1)
-	metrics.OrchestratorCacheEvictSubscope(o.scope, key).Counter(metrics.OrchestratorOnCacheEvictedRequestCount).Inc(len(resource.Requests))
+	metrics.OrchestratorCacheEvictSubscope(o.scope, key).Counter(
+		metrics.OrchestratorOnCacheEvictedRequestCount).Inc(int64(len(resource.Requests)))
 	o.logger.With("aggregated_key", key).Debug(context.Background(), "cache eviction called")
 	o.downstreamResponseMap.deleteAll(resource.Requests)
 	o.upstreamResponseMap.delete(key)

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -369,8 +369,9 @@ func (o *orchestrator) fanout(resp *discovery.DiscoveryResponse, watchers map[*g
 func (o *orchestrator) onCacheEvicted(key string, resource cache.Resource) {
 	// TODO Potential for improvements here to handle the thundering herd
 	// problem: https://github.com/envoyproxy/xds-relay/issues/71
-	metrics.OrchestratorWatchSubscope(o.scope, key).Counter(metrics.OrchestratorOnCacheEvict).Inc(1)
-	o.logger.With("aggregated_key", key, "resource", resource).Debug(context.Background(), "cache eviction called")
+	metrics.OrchestratorCacheEvictSubscope(o.scope, key).Counter(metrics.OrcheestratorCacheEvictCount).Inc(1)
+	metrics.OrchestratorCacheEvictSubscope(o.scope, key).Counter(metrics.OrchestratorOnCacheEvictedRequestCount).Inc(len(resource.Requests))
+	o.logger.With("aggregated_key", key).Debug(context.Background(), "cache eviction called")
 	o.downstreamResponseMap.deleteAll(resource.Requests)
 	o.upstreamResponseMap.delete(key)
 }


### PR DESCRIPTION
Although the language specification for Go specifies that channels will
be garbage collected when no longer referenced, the receiver (
go-control-plane in this scenario) may be still looking for an explicit
signal. In our experiments, we saw that there were scenarios where cache
TTL triggering removal of downstream watchers, did not cause the Envoy
clients to resend requests.

Signed-off-by: Jess Yuen <jyuen@lyft.com>