### PR TITLE
Statsd Point Tags Reporter

### DIFF
--- a/internal/app/cache/cache_test.go
+++ b/internal/app/cache/cache_test.go
@@ -92,10 +92,12 @@ func TestAddRequestAndFetch(t *testing.T) {
 
 	err = cache.AddRequest(testKeyA, &testRequestA)
 	assert.NoError(t, err)
-	testutils.AssertCounterValue(
-		t, mockScope.Snapshot().Counters(), fmt.Sprintf("cache.%s.add_request.attempt", testKeyA), 1)
-	testutils.AssertCounterValue(
-		t, mockScope.Snapshot().Counters(), fmt.Sprintf("cache.%s.add_request.success", testKeyA), 1)
+	countersSnapshot := mockScope.Snapshot().Counters()
+	fmt.Println(countersSnapshot)
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("cache.add_request.attempt+key=%v", testKeyA)].Value())
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("cache.add_request.success+key=%v", testKeyA)].Value())
 
 	resource, err = cache.Fetch(testKeyA)
 	assert.NoError(t, err)

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -5,6 +5,8 @@ import (
 	"github.com/uber-go/tally"
 )
 
+const TagName = "key"
+
 // .server
 const (
 	// scope: .server.*
@@ -133,10 +135,11 @@ func CacheSetSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheSet)
 }
 
-// CacheAddRequestSubscope gets the cache add request subscope for the aggregated key.
-// ex: .cache.$aggregated_key.add_request
+// CacheAddRequestSubscope gets the cache add request subscope and adds the the aggregated key
+// as a point tag.
+// ex: .cache.add_request+key=$aggregated_key
 func CacheAddRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{"key": aggregatedKey})
+	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
 // CacheDeleteRequestSubscope gets the cache delete request subscope for the aggregated key.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -129,21 +129,22 @@ func CacheFetchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheFetch)
 }
 
-// CacheSetSubscope gets the cache set subscope for the aggregated key.
-// ex: .cache.$aggregated_key.set_response
+// CacheSetSubscope gets the cache set subscope and adds the aggregated key as a point tag.
+// ex: .cache.set_response+key=$aggregated_key
 func CacheSetSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheSet)
+	return parent.SubScope(ScopeCacheSet).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// CacheAddRequestSubscope gets the cache add request subscope and adds the the aggregated key
+// CacheAddRequestSubscope gets the cache add request subscope and adds the aggregated key
 // as a point tag.
 // ex: .cache.add_request+key=$aggregated_key
 func CacheAddRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// CacheDeleteRequestSubscope gets the cache delete request subscope for the aggregated key.
-// ex: .cache.$aggregated_key.delete_request
+// CacheDeleteRequestSubscope gets the cache delete request subscope and adds the aggregated key
+// as a point tag.
+// ex: .cache.delete_request+key=$aggregated_key
 func CacheDeleteRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheDelete)
+	return parent.SubScope(ScopeCacheDelete).Tagged(map[string]string{TagName: aggregatedKey})
 }

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -105,22 +105,25 @@ const (
 	ErrorInterceptorErrorRecvMsg = "error_recvmsg"
 )
 
-// OrchestratorWatchSubscope gets the orchestor watch subscope for the aggregated key.
-// ex: .orchestrator.$aggregated_key.watch
+// OrchestratorWatchSubscope gets the orchestor watch subscope and adds the aggregated key as a point tag.
+// ex: .orchestrator.watch+key=$aggregated_key
 func OrchestratorWatchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorWatch)
+	return parent.SubScope(ScopeOrchestratorWatch).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// OrchestratorWatchErrorsSubscope gets the orchestor watch errora subscope for the aggregated key.
-// ex: .orchestrator.$aggregated_key.watch.errors
+// OrchestratorWatchErrorsSubscope gets the orchestor watch errors subscope and adds the aggregated key
+// as a point tag.
+// ex: .orchestrator.watch.errors+key=$aggregated_key.
 func OrchestratorWatchErrorsSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorWatch).SubScope(ScopeOrchestratorWatchErrors)
+	watchErrorsSubScope := parent.SubScope(ScopeOrchestratorWatch).SubScope(ScopeOrchestratorWatchErrors)
+	return watchErrorsSubScope.Tagged(map[string]string{TagName: aggregatedKey})
 }
 
-// OrchestratorCacheEvictSubscope gets the orchestor cache evict subscope for the aggregated key.
-// ex: .orchestrator.$aggregated_key.cache_evict
+// OrchestratorCacheEvictSubscope gets the orchestor cache evict subscope and adds the aggregated key
+// as a point tag.
+// ex: .orchestrator.cache_evict+key=$aggregated_key.
 func OrchestratorCacheEvictSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorCacheEvict)
+	return parent.SubScope(ScopeOrchestratorCacheEvict).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
 // CacheFetchSubscope gets the cache fetch subscope and adds the aggregated key as a point tag.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -136,7 +136,7 @@ func CacheSetSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 // CacheAddRequestSubscope gets the cache add request subscope for the aggregated key.
 // ex: .cache.$aggregated_key.add_request
 func CacheAddRequestSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheAdd)
+	return parent.SubScope(ScopeCacheAdd).Tagged(map[string]string{"key": aggregatedKey})
 }
 
 // CacheDeleteRequestSubscope gets the cache delete request subscope for the aggregated key.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -123,10 +123,10 @@ func OrchestratorCacheEvictSubscope(parent tally.Scope, aggregatedKey string) ta
 	return parent.SubScope(aggregatedKey).SubScope(ScopeOrchestratorCacheEvict)
 }
 
-// CacheFetchSubscope gets the cache fetch subscope for the aggregated key.
-// ex: .cache.$aggregated_key.fetch
+// CacheFetchSubscope gets the cache fetch subscope and adds the aggregated key as a point tag.
+// ex: .cache.fetch+key=$aggregated_key
 func CacheFetchSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
-	return parent.SubScope(aggregatedKey).SubScope(ScopeCacheFetch)
+	return parent.SubScope(ScopeCacheFetch).Tagged(map[string]string{TagName: aggregatedKey})
 }
 
 // CacheSetSubscope gets the cache set subscope and adds the aggregated key as a point tag.

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -136,8 +136,9 @@ func TestGoldenPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	respChannel, cancelWatch := orchestrator.CreateWatch(req)
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.created", aggregatedKey), 1)
+	countersSnapshot := mockScope.Snapshot().Counters()
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.created+key=%v", aggregatedKey)].Value())
 	assert.NotNil(t, respChannel)
 	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
 	testutils.AssertSyncMapLen(t, 1, orchestrator.upstreamResponseMap.internal)
@@ -167,10 +168,11 @@ func TestGoldenPath(t *testing.T) {
 
 	cancelWatch()
 
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.fanout", aggregatedKey), 1)
-	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.%s.watch.canceled", aggregatedKey), 1)
+	countersSnapshot = mockScope.Snapshot().Counters()
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.fanout+key=%v", aggregatedKey)].Value())
+	assert.EqualValues(
+		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.canceled+key=%v", aggregatedKey)].Value())
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
 }
 

--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -68,7 +68,7 @@ func RunWithContext(ctx context.Context, cancel context.CancelFunc, bootstrapCon
 	// Initialize metrics sink. For now we default to statsd.
 	statsdPort := strconv.FormatUint(uint64(bootstrapConfig.MetricsSink.GetStatsd().Address.PortValue), 10)
 	statsdAddress := net.JoinHostPort(bootstrapConfig.MetricsSink.GetStatsd().Address.Address, statsdPort)
-	scope, scopeCloser, err := stats.NewScope(stats.Config{
+	scope, scopeCloser, err := stats.NewRootScope(stats.Config{
 		StatsdAddress: statsdAddress,
 		RootPrefix:    bootstrapConfig.MetricsSink.GetStatsd().RootPrefix,
 		FlushInterval: time.Duration(bootstrapConfig.MetricsSink.GetStatsd().FlushInterval.Nanos),

--- a/internal/pkg/stats/stats.go
+++ b/internal/pkg/stats/stats.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cactus/go-statsd-client/statsd"
 	"github.com/uber-go/tally"
-	tallystatsd "github.com/uber-go/tally/statsd"
 )
 
 // Config holds the configuration options for stats reporting.
@@ -23,9 +22,9 @@ type Config struct {
 	FlushInterval time.Duration
 }
 
-// NewScope creates a new root Scope with the set of configured options and
+// NewRootScope creates a new root Scope with the set of configured options and
 // statsd reporter.
-func NewScope(config Config) (tally.Scope, io.Closer, error) {
+func NewRootScope(config Config) (tally.Scope, io.Closer, error) {
 	// Configure statsd client for reporting stats.
 	statsdClient, err := statsd.NewClientWithConfig(&statsd.ClientConfig{
 		Address:       config.StatsdAddress,
@@ -36,7 +35,7 @@ func NewScope(config Config) (tally.Scope, io.Closer, error) {
 		return nil, nil, err
 	}
 
-	reporter := tallystatsd.NewReporter(statsdClient, tallystatsd.Options{})
+	reporter := NewStatsdPointTagsReporter(statsdClient)
 
 	scope, closer := tally.NewRootScope(tally.ScopeOptions{
 		Prefix:   config.RootPrefix,

--- a/internal/pkg/stats/statsd_point_tags_reporter.go
+++ b/internal/pkg/stats/statsd_point_tags_reporter.go
@@ -1,0 +1,66 @@
+package stats
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/uber-go/tally"
+	tallystatsd "github.com/uber-go/tally/statsd"
+)
+
+func NewStatsdPointTagsReporter(statsdClient statsd.Statter) tally.StatsReporter {
+	reporter := tallystatsd.NewReporter(statsdClient, tallystatsd.Options{})
+	return &pointTagsReporter{
+		StatsReporter: reporter,
+	}
+}
+
+type pointTagsReporter struct {
+	tally.StatsReporter
+}
+
+func (r *pointTagsReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	r.StatsReporter.ReportCounter(r.buildTaggedName(name, tags), nil, value)
+}
+
+func (r *pointTagsReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	r.StatsReporter.ReportGauge(r.buildTaggedName(name, tags), nil, value)
+}
+
+func (r *pointTagsReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+	r.StatsReporter.ReportTimer(r.buildTaggedName(name, tags), nil, interval)
+}
+
+func (r *pointTagsReporter) buildTaggedName(name string, tags map[string]string) string {
+	var b strings.Builder
+	b.WriteString(name)
+	for k, v := range tags {
+		// We assume that the tags are of the form "a.b.c.__tag1=value1.__tag2=value2", where "a.b.c" is
+		// a metric name.
+		b.WriteString(".__")
+		b.WriteString(sanitize(k))
+		b.WriteByte('=')
+		b.WriteString(sanitize(v))
+	}
+	return b.String()
+}
+
+// Instead of panic'ing in the case of invalid tags, we simply replace the invalid characters with
+// the character '_'.
+func sanitize(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if isValidChar(r) {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+func isValidChar(r rune) bool {
+	return ('0' <= r && r <= '9') || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z') || r == '-' || r == '_' || r == '.'
+}

--- a/internal/pkg/stats/statsd_point_tags_reporter_test.go
+++ b/internal/pkg/stats/statsd_point_tags_reporter_test.go
@@ -1,0 +1,66 @@
+package stats
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
+)
+
+type mockReporter struct {
+	tally.StatsReporter
+
+	actualName string
+}
+
+func (m *mockReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	m.actualName = name
+}
+
+var tests = []struct {
+	name         string
+	tags         map[string]string
+	expectedTags map[string]string
+}{
+	{
+		name:         "a.b.c",
+		tags:         map[string]string{"tag1": "value1"},
+		expectedTags: map[string]string{"tag1": "value1"},
+	},
+	{
+		name:         "a-b.c-d",
+		tags:         map[string]string{"tag1": "value|1", "tag2": "value.2"},
+		expectedTags: map[string]string{"tag1": "value_1", "tag2": "value.2"},
+	},
+	{
+		name:         "a",
+		tags:         map[string]string{"tag1": "value-1", "tag2": "value 2", "tag:3": "value:3"},
+		expectedTags: map[string]string{"tag1": "value-1", "tag2": "value_2", "tag_3": "value_3"},
+	},
+}
+
+func TestPointTagReporter(t *testing.T) {
+	for idx, tt := range tests {
+		tt := tt
+		t.Run(fmt.Sprintf("%d", idx), func(t *testing.T) {
+			t.Parallel()
+
+			m := &mockReporter{}
+			p := pointTagsReporter{
+				StatsReporter: m,
+			}
+			p.ReportCounter(tt.name, tt.tags, 10)
+
+			actualTags := map[string]string{}
+			for _, v := range strings.Split(m.actualName, ".__")[1:] {
+				ss := strings.Split(v, "=")
+				actualTags[ss[0]] = ss[1]
+			}
+
+			assert.Equal(t, tt.expectedTags, actualTags)
+			assert.True(t, strings.HasPrefix(m.actualName, tt.name))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a statsd reporter with support for point tags using the format used by Lyft. Follow up PRs could extend this approach to generalize the creation of point tags, but I opted for the simplest-yet-extensible solution for now.

In this PR we convert the metrics that contained the aggregated key in the metric name to use the new format where the aggregated key becomes a point tag.

Signed-off-by: eapolinario <eapolinario@lyft.com>