### PR TITLE
Remove redirect behavior for admin endpoints and support getting log level

### DIFF
--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Handler struct {
-	prefix      string
+	pattern     string
 	description string
 	handler     http.HandlerFunc
 }
@@ -42,13 +42,14 @@ func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 			func(http.ResponseWriter, *http.Request) {},
 		},
 		{
-			"/cache/",
-			"print cache entry for a given key. usage: `/cache/<key>`",
+			"/cache",
+			"print cache entry for a given key. Omitting the key outputs all cache entries. usage: `/cache/<key>`",
 			cacheDumpHandler(orchestrator),
 		},
 		{
-			"/log_level/",
-			"update the log level to `debug`, `info`, `warn`, or `error`. usage: `/log_level/<level>`",
+			"/log_level",
+			"update the log level to `debug`, `info`, `warn`, or `error`. " +
+				"Omitting the level outputs the current log level. usage: `/log_level/<level>`",
 			logLevelHandler(logger),
 		},
 		{
@@ -66,7 +67,10 @@ func RegisterHandlers(bootstrapConfig *bootstrapv1.Bootstrap,
 	orchestrator *orchestrator.Orchestrator,
 	logger log.Logger) {
 	for _, handler := range getHandlers(bootstrapConfig, orchestrator, logger) {
-		http.Handle(handler.prefix, handler.handler)
+		http.Handle(handler.pattern, handler.handler)
+		if !strings.HasSuffix(handler.pattern, "/") {
+			http.Handle(handler.pattern+"/", handler.handler)
+		}
 	}
 }
 
@@ -80,7 +84,7 @@ func defaultHandler(handlers []Handler) http.HandlerFunc {
 		}
 		fmt.Fprintf(w, "admin commands are:\n")
 		for _, handler := range handlers {
-			fmt.Fprintf(w, "  %s: %s\n", handler.prefix, handler.description)
+			fmt.Fprintf(w, "  %s: %s\n", handler.pattern, handler.description)
 		}
 	}
 }
@@ -100,12 +104,7 @@ func configDumpHandler(bootstrapConfig *bootstrapv1.Bootstrap) http.HandlerFunc 
 // TODO(lisalu): Support dump of matching resources when cache key regex is provided.
 func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		cacheKey, err := getParam(req.URL.Path)
-		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			fmt.Fprintf(w, "unable to parse cache key from path: %s", err.Error())
-			return
-		}
+		cacheKey := getParam(req.URL.Path)
 		cache := orchestrator.Orchestrator.GetReadOnlyCache(*o)
 
 		// If no key is provided, output the entire cache.
@@ -261,24 +260,27 @@ func marshalResources(Resources []*any.Any) *xDSResources {
 	return &marshalledResources
 }
 
-func getParam(path string) (string, error) {
+func getParam(path string) string {
 	// Assumes that the URL is of the format `address/endpoint/parameter` and returns `parameter`.
 	splitPath := strings.SplitN(path, "/", 3)
 	if len(splitPath) == 3 {
-		return splitPath[2], nil
+		return splitPath[2]
 	}
-	return "", fmt.Errorf("unable to parse parameter from path: %s", path)
+	return ""
 }
 
 func logLevelHandler(l log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "POST" {
-			logLevel, err := getParam(req.URL.Path)
-			if err != nil {
-				w.WriteHeader(http.StatusBadRequest)
-				fmt.Fprintf(w, "unable to parse log level from path: %s", err.Error())
+			logLevel := getParam(req.URL.Path)
+
+			// If no key is provided, output the current log level.
+			if logLevel == "" {
+				fmt.Fprintf(w, "Current log level: %s\n", l.GetLevel())
 				return
 			}
+
+			// Otherwise update the logging level.
 			_, parseLogLevelErr := zap.ParseLogLevel(logLevel)
 			if parseLogLevelErr != nil {
 				w.WriteHeader(http.StatusBadRequest)

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -288,6 +288,7 @@ func logLevelHandler(l log.Logger) http.HandlerFunc {
 				return
 			}
 			l.UpdateLogLevel(logLevel)
+			fmt.Fprintf(w, "Current log level: %s\n", l.GetLevel())
 		} else {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			fmt.Fprintf(w, "Only POST is supported\n")

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -371,6 +371,7 @@ func TestAdminServer_LogLevelHandler(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, rr.Body.String(), "Current log level: debug\n")
 	logger.Debug(ctx, "bar")
 	output = buf.String()
 	assert.Contains(t, output, "bar")
@@ -380,6 +381,7 @@ func TestAdminServer_LogLevelHandler(t *testing.T) {
 
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), "Current log level: info\n")
 	logger.Debug(ctx, "baz")
 	logger.Info(ctx, "qux")
 	output = buf.String()

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -57,24 +57,24 @@ func TestAdminServer_DefaultHandler_NotFound(t *testing.T) {
 }
 
 func TestAdminServer_ConfigDumpHandler(t *testing.T) {
-	req, err := http.NewRequest("GET", "/server_info", nil)
-	assert.NoError(t, err)
+	for _, url := range []string{"/server_info", "/server_info/"} {
+		req, err := http.NewRequest("GET", url, nil)
+		assert.NoError(t, err)
+		rr := httptest.NewRecorder()
+		handler := configDumpHandler(&bootstrapv1.Bootstrap{
+			Server: &bootstrapv1.Server{Address: &bootstrapv1.SocketAddress{
+				Address:   "127.0.0.1",
+				PortValue: 9991,
+			}},
+			OriginServer: nil,
+			Logging:      nil,
+			Cache:        nil,
+		})
 
-	rr := httptest.NewRecorder()
-	handler := configDumpHandler(&bootstrapv1.Bootstrap{
-		Server: &bootstrapv1.Server{Address: &bootstrapv1.SocketAddress{
-			Address:   "127.0.0.1",
-			PortValue: 9991,
-		}},
-		OriginServer: nil,
-		Logging:      nil,
-		Cache:        nil,
-	})
-
-	handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Equal(t,
-		`{
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t,
+			`{
   "server": {
     "address": {
       "address": "127.0.0.1",
@@ -83,7 +83,8 @@ func TestAdminServer_ConfigDumpHandler(t *testing.T) {
   }
 }
 `,
-		rr.Body.String())
+			rr.Body.String())
+	}
 }
 
 func TestAdminServer_CacheDumpHandler(t *testing.T) {
@@ -196,81 +197,82 @@ func TestAdminServer_CacheDumpHandler_NotFound(t *testing.T) {
 }
 
 func TestAdminServer_CacheDumpHandler_EntireCache(t *testing.T) {
-	ctx := context.Background()
-	mapper := mapper.NewMock(t)
-	upstreamResponseChannelLDS := make(chan *v2.DiscoveryResponse)
-	upstreamResponseChannelCDS := make(chan *v2.DiscoveryResponse)
-	mockScope := tally.NewTestScope("mock_orchestrator", make(map[string]string))
-	client := upstream.NewMock(
-		ctx,
-		upstream.CallOptions{Timeout: time.Second},
-		nil,
-		upstreamResponseChannelLDS,
-		nil,
-		nil,
-		upstreamResponseChannelCDS,
-		func(m interface{}) error { return nil },
-	)
-	orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
-	assert.NotNil(t, orchestrator)
+	for _, url := range []string{"/cache", "/cache/"} {
+		ctx := context.Background()
+		mapper := mapper.NewMock(t)
+		upstreamResponseChannelLDS := make(chan *v2.DiscoveryResponse)
+		upstreamResponseChannelCDS := make(chan *v2.DiscoveryResponse)
+		mockScope := tally.NewTestScope("mock_orchestrator", make(map[string]string))
+		client := upstream.NewMock(
+			ctx,
+			upstream.CallOptions{Timeout: time.Second},
+			nil,
+			upstreamResponseChannelLDS,
+			nil,
+			nil,
+			upstreamResponseChannelCDS,
+			func(m interface{}) error { return nil },
+		)
+		orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
+		assert.NotNil(t, orchestrator)
 
-	gcpReq := gcp.Request{
-		TypeUrl: "type.googleapis.com/envoy.api.v2.Listener",
-	}
-	ldsRespChannel, cancelLDSWatch := orchestrator.CreateWatch(gcpReq)
-	assert.NotNil(t, ldsRespChannel)
+		gcpReq := gcp.Request{
+			TypeUrl: "type.googleapis.com/envoy.api.v2.Listener",
+		}
+		ldsRespChannel, cancelLDSWatch := orchestrator.CreateWatch(gcpReq)
+		assert.NotNil(t, ldsRespChannel)
 
-	gcpReq = gcp.Request{
-		TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
-	}
-	cdsRespChannel, cancelCDSWatch := orchestrator.CreateWatch(gcpReq)
-	assert.NotNil(t, cdsRespChannel)
+		gcpReq = gcp.Request{
+			TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
+		}
+		cdsRespChannel, cancelCDSWatch := orchestrator.CreateWatch(gcpReq)
+		assert.NotNil(t, cdsRespChannel)
 
-	listener := &v2.Listener{
-		Name: "lds resource",
-	}
-	listenerAny, err := ptypes.MarshalAny(listener)
-	assert.NoError(t, err)
-	resp := v2.DiscoveryResponse{
-		VersionInfo: "1",
-		TypeUrl:     "type.googleapis.com/envoy.api.v2.Listener",
-		Resources: []*any.Any{
-			listenerAny,
-		},
-	}
-	upstreamResponseChannelLDS <- &resp
-	gotResponse := <-ldsRespChannel
-	gotDiscoveryResponse, err := gotResponse.GetDiscoveryResponse()
-	assert.NoError(t, err)
-	assert.Equal(t, resp, *gotDiscoveryResponse)
+		listener := &v2.Listener{
+			Name: "lds resource",
+		}
+		listenerAny, err := ptypes.MarshalAny(listener)
+		assert.NoError(t, err)
+		resp := v2.DiscoveryResponse{
+			VersionInfo: "1",
+			TypeUrl:     "type.googleapis.com/envoy.api.v2.Listener",
+			Resources: []*any.Any{
+				listenerAny,
+			},
+		}
+		upstreamResponseChannelLDS <- &resp
+		gotResponse := <-ldsRespChannel
+		gotDiscoveryResponse, err := gotResponse.GetDiscoveryResponse()
+		assert.NoError(t, err)
+		assert.Equal(t, resp, *gotDiscoveryResponse)
 
-	cluster := &v2.Cluster{
-		Name: "cds resource",
-	}
-	clusterAny, err := ptypes.MarshalAny(cluster)
-	assert.NoError(t, err)
-	resp = v2.DiscoveryResponse{
-		VersionInfo: "2",
-		TypeUrl:     "type.googleapis.com/envoy.api.v2.Cluster",
-		Resources: []*any.Any{
-			clusterAny,
-		},
-	}
-	upstreamResponseChannelCDS <- &resp
-	gotResponse = <-cdsRespChannel
-	gotDiscoveryResponse, err = gotResponse.GetDiscoveryResponse()
-	assert.NoError(t, err)
-	assert.Equal(t, resp, *gotDiscoveryResponse)
+		cluster := &v2.Cluster{
+			Name: "cds resource",
+		}
+		clusterAny, err := ptypes.MarshalAny(cluster)
+		assert.NoError(t, err)
+		resp = v2.DiscoveryResponse{
+			VersionInfo: "2",
+			TypeUrl:     "type.googleapis.com/envoy.api.v2.Cluster",
+			Resources: []*any.Any{
+				clusterAny,
+			},
+		}
+		upstreamResponseChannelCDS <- &resp
+		gotResponse = <-cdsRespChannel
+		gotDiscoveryResponse, err = gotResponse.GetDiscoveryResponse()
+		assert.NoError(t, err)
+		assert.Equal(t, resp, *gotDiscoveryResponse)
 
-	req, err := http.NewRequest("GET", "/cache/", nil)
-	assert.NoError(t, err)
+		req, err := http.NewRequest("GET", url, nil)
+		assert.NoError(t, err)
 
-	rr := httptest.NewRecorder()
-	handler := cacheDumpHandler(&orchestrator)
+		rr := httptest.NewRecorder()
+		handler := cacheDumpHandler(&orchestrator)
 
-	handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusOK, rr.Code)
-	assert.Contains(t, rr.Body.String(), `lds: {
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), `lds: {
   "Resp": {
     "VersionInfo": "1",
     "Resources": {
@@ -297,7 +299,7 @@ func TestAdminServer_CacheDumpHandler_EntireCache(t *testing.T) {
     }
   ],
   "ExpirationTime": "`)
-	assert.Contains(t, rr.Body.String(), `cds: {
+		assert.Contains(t, rr.Body.String(), `cds: {
   "Resp": {
     "VersionInfo": "2",
     "Resources": {
@@ -326,28 +328,26 @@ func TestAdminServer_CacheDumpHandler_EntireCache(t *testing.T) {
     }
   ],
   "ExpirationTime": "`)
-	cancelLDSWatch()
-	cancelCDSWatch()
+		cancelLDSWatch()
+		cancelCDSWatch()
+	}
 }
 
 func TestGetParam(t *testing.T) {
 	path := "127.0.0.1:6070/cache/foo_production_*"
-	cacheKey, err := getParam(path)
-	assert.NoError(t, err)
+	cacheKey := getParam(path)
 	assert.Equal(t, "foo_production_*", cacheKey)
 }
 
 func TestGetParam_Empty(t *testing.T) {
 	path := "127.0.0.1:6070/cache/"
-	cacheKey, err := getParam(path)
-	assert.NoError(t, err)
+	cacheKey := getParam(path)
 	assert.Equal(t, "", cacheKey)
 }
 
 func TestGetParam_Malformed(t *testing.T) {
 	path := "127.0.0.1:6070"
-	cacheKey, err := getParam(path)
-	assert.Error(t, err, "")
+	cacheKey := getParam(path)
 	assert.Equal(t, "", cacheKey)
 }
 
@@ -385,6 +385,37 @@ func TestAdminServer_LogLevelHandler(t *testing.T) {
 	output = buf.String()
 	assert.NotContains(t, output, "baz")
 	assert.Contains(t, output, "qux")
+}
+
+func TestAdminServer_LogLevelHandler_GetLevel(t *testing.T) {
+	for _, url := range []string{"/log_level", "/log_level/"} {
+		var buf bytes.Buffer
+		logger := log.NewMock("error", &buf)
+		assert.Equal(t, 0, buf.Len())
+
+		req, err := http.NewRequest("POST", url, nil)
+		assert.NoError(t, err)
+
+		rr := httptest.NewRecorder()
+		handler := logLevelHandler(logger)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, rr.Body.String(), "Current log level: error\n")
+
+		req, err = http.NewRequest("POST", "/log_level/info", nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		req, err = http.NewRequest("POST", url, nil)
+		assert.NoError(t, err)
+
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Contains(t, rr.Body.String(), "Current log level: info\n")
+	}
 }
 
 func TestMarshalResources(t *testing.T) {

--- a/internal/app/server/server_test.go
+++ b/internal/app/server/server_test.go
@@ -58,3 +58,4 @@ func (l *logger) Error(ctx context.Context, template string, args ...interface{}
 	l.blockedCh <- true
 }
 func (l *logger) UpdateLogLevel(logLevel string) {}
+func (l *logger) GetLevel() string               { return "" }

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -60,5 +60,9 @@ type Logger interface {
 	// Sync flushes any buffered log entries.
 	Sync() error
 
+	// UpdateLogLevel reinitializes the logger at the given level.
 	UpdateLogLevel(logLevel string)
+
+	// GetLevel returns the logger's level as a human-readable string.
+	GetLevel() string
 }

--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -11,6 +11,7 @@ import (
 type logger struct {
 	zap     *z.SugaredLogger
 	writeTo io.Writer
+	level   string
 }
 
 // New returns an instance of Logger implemented using the Zap logging framework.
@@ -35,7 +36,7 @@ func New(logLevel string, writeTo io.Writer) Logger {
 	}
 
 	log = log.With(z.Namespace("json"))
-	return &logger{zap: log.Sugar(), writeTo: writeTo}
+	return &logger{zap: log.Sugar(), writeTo: writeTo, level: zLevel.String()}
 }
 
 // UpdateLevel updates the logging level for the logger instance by
@@ -58,6 +59,12 @@ func (l *logger) UpdateLogLevel(logLevel string) {
 
 	log = log.With(z.Namespace("json"))
 	l.zap = log.Sugar()
+	l.level = zLevel.String()
+}
+
+// GetLevel returns the logging level in human-readable string format..
+func (l *logger) GetLevel() string {
+	return l.level
 }
 
 func (l *logger) Named(name string) Logger {

--- a/internal/pkg/log/zap.go
+++ b/internal/pkg/log/zap.go
@@ -62,7 +62,7 @@ func (l *logger) UpdateLogLevel(logLevel string) {
 	l.level = zLevel.String()
 }
 
-// GetLevel returns the logging level in human-readable string format..
+// GetLevel returns the logging level in human-readable string format.
 func (l *logger) GetLevel() string {
 	return l.level
 }


### PR DESCRIPTION
This change:

- Supports returning the current log level in string format when no parameter is supplied to the admin logging endpoint.
- Handles trailing slashes in URLs, such that paths with and without are registered to the same handlers without any redirects. [The redirects are a characteristic of http handlers in Go](https://golang.org/pkg/net/http/#ServeMux):
```If a subtree has been registered and a request is received naming the subtree root without its trailing slash, ServeMux redirects that request to the subtree root (adding the trailing slash). This behavior can be overridden with a separate registration for the path without the trailing slash. For example, registering "/images/" causes ServeMux to redirect a request for "/images" to "/images/", unless "/images" has been registered separately.```

Fixes #127 