### PR TITLE
Add Request/Response abstraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/uber-go/tally v3.3.15+incompatible
 	go.uber.org/zap v1.14.0
 	golang.org/x/tools v0.0.0-20200527150044-688b3c5d9fa5 // indirect
+	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a
 	google.golang.org/grpc v1.27.1
 	google.golang.org/protobuf v1.20.1
 )

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -20,6 +20,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/xds-relay/internal/app/cache"
+	"github.com/envoyproxy/xds-relay/internal/app/transport"
 
 	"github.com/envoyproxy/xds-relay/internal/app/orchestrator"
 
@@ -156,7 +157,7 @@ type marshallableResource struct {
 func resourceToString(resource cache.Resource) (string, error) {
 	var requests []*v2.DiscoveryRequest
 	for request := range resource.Requests {
-		requests = append(requests, request)
+		requests = append(requests, request.GetRaw().(*v2.DiscoveryRequest))
 	}
 
 	resourceString := &marshallableResource{
@@ -187,8 +188,9 @@ type xDSResources struct {
 	Unmarshalled []*any.Any
 }
 
-func marshalDiscoveryResponse(resp *v2.DiscoveryResponse) *marshalledDiscoveryResponse {
-	if resp != nil {
+func marshalDiscoveryResponse(r transport.Response) *marshalledDiscoveryResponse {
+	if r != nil {
+		resp := r.Get().(*v2.DiscoveryResponse)
 		marshalledResp := marshalledDiscoveryResponse{
 			VersionInfo:  resp.VersionInfo,
 			Canary:       resp.Canary,

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -157,7 +157,7 @@ type marshallableResource struct {
 func resourceToString(resource cache.Resource) (string, error) {
 	var requests []*v2.DiscoveryRequest
 	for request := range resource.Requests {
-		requests = append(requests, request.GetRaw().(*v2.DiscoveryRequest))
+		requests = append(requests, request.GetRaw().V2)
 	}
 
 	resourceString := &marshallableResource{
@@ -190,7 +190,7 @@ type xDSResources struct {
 
 func marshalDiscoveryResponse(r transport.Response) *marshalledDiscoveryResponse {
 	if r != nil {
-		resp := r.Get().(*v2.DiscoveryResponse)
+		resp := r.Get().V2
 		marshalledResp := marshalledDiscoveryResponse{
 			VersionInfo:  resp.VersionInfo,
 			Canary:       resp.Canary,

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/envoyproxy/xds-relay/internal/app/transport"
 	"github.com/envoyproxy/xds-relay/internal/app/upstream"
 
 	"github.com/envoyproxy/xds-relay/internal/pkg/log"
@@ -159,6 +160,7 @@ func TestAdminServer_CacheDumpHandler(t *testing.T) {
   },
   "Requests": [
     {
+      "version_info": "1",
       "type_url": "type.googleapis.com/envoy.api.v2.Listener"
     }
   ],
@@ -293,6 +295,7 @@ func TestAdminServer_CacheDumpHandler_EntireCache(t *testing.T) {
   },
   "Requests": [
     {
+      "version_info": "1",
       "type_url": "type.googleapis.com/envoy.api.v2.Listener"
     }
   ],
@@ -322,6 +325,7 @@ func TestAdminServer_CacheDumpHandler_EntireCache(t *testing.T) {
   },
   "Requests": [
     {
+      "version_info": "2",
       "type_url": "type.googleapis.com/envoy.api.v2.Cluster"
     }
   ],
@@ -414,7 +418,7 @@ func TestMarshalDiscoveryResponse(t *testing.T) {
 			listenerAny,
 		},
 	}
-	marshalled := marshalDiscoveryResponse(&resp)
+	marshalled := marshalDiscoveryResponse(transport.NewResponseV2(&gcp.Request{}, &resp))
 	assert.NotNil(t, marshalled)
 	assert.Equal(t, resp.VersionInfo, marshalled.VersionInfo)
 	assert.Equal(t, resp.TypeUrl, marshalled.TypeURL)

--- a/internal/app/cache/cache_test.go
+++ b/internal/app/cache/cache_test.go
@@ -125,7 +125,7 @@ func TestSetResponseAndFetch(t *testing.T) {
 
 	resource, err = cache.Fetch(testKeyA)
 	assert.NoError(t, err)
-	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get())
+	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get().V2)
 }
 
 func TestAddRequestAndSetResponse(t *testing.T) {
@@ -148,7 +148,7 @@ func TestAddRequestAndSetResponse(t *testing.T) {
 
 	resource, err := cache.Fetch(testKeyA)
 	assert.NoError(t, err)
-	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get())
+	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get().V2)
 }
 
 func TestMaxEntries(t *testing.T) {
@@ -160,7 +160,7 @@ func TestMaxEntries(t *testing.T) {
 
 	resource, err := cache.Fetch(testKeyA)
 	assert.NoError(t, err)
-	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get())
+	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get().V2)
 
 	assert.PanicsWithValue(t, panicValues{
 		key:    testKeyA,
@@ -188,7 +188,7 @@ func TestTTL_Enabled(t *testing.T) {
 
 	resource, err := cache.Fetch(testKeyA)
 	assert.NoError(t, err)
-	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get())
+	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get().V2)
 
 	time.Sleep(time.Millisecond * 10)
 	assert.PanicsWithValue(t, panicValues{
@@ -215,7 +215,7 @@ func TestTTL_Disabled(t *testing.T) {
 
 	resource, err := cache.Fetch(testKeyA)
 	assert.NoError(t, err)
-	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get())
+	assert.Equal(t, &testDiscoveryResponse, resource.Resp.Get().V2)
 
 	gomega.Consistently(func() (*Resource, error) {
 		return cache.Fetch(testKeyA)

--- a/internal/app/mapper/mapper_test.go
+++ b/internal/app/mapper/mapper_test.go
@@ -5,6 +5,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/xds-relay/internal/app/transport"
 	"github.com/envoyproxy/xds-relay/internal/pkg/stats"
 	aggregationv1 "github.com/envoyproxy/xds-relay/pkg/api/aggregation/v1"
 	. "github.com/onsi/ginkgo"
@@ -1108,7 +1109,7 @@ var _ = Describe("GetKey", func() {
 			mapper := New(&protoConfig, mockScope)
 			request := getDiscoveryRequest()
 			request.TypeUrl = typeurl
-			key, err := mapper.GetKey(request)
+			key, err := mapper.GetKey(transport.NewRequestV2(&request))
 			Expect(mockScope.Snapshot().Counters()["mock.mapper.success+"].Value()).To(Equal(int64(1)))
 			Expect(key).To(Equal(assert))
 			Expect(err).Should(BeNil())
@@ -1130,7 +1131,7 @@ var _ = Describe("GetKey", func() {
 			}
 			mockScope := stats.NewMockScope("mock")
 			mapper := New(&protoConfig, mockScope)
-			key, err := mapper.GetKey(request)
+			key, err := mapper.GetKey(transport.NewRequestV2(&request))
 			Expect(mockScope.Snapshot().Counters()["mock.mapper.error+"].Value()).To(Equal(int64(1)))
 			Expect(key).To(Equal(""))
 			Expect(err).Should(Equal(fmt.Errorf("Cannot map the input to a key")))
@@ -1164,7 +1165,8 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := New(&protoConfig, stats.NewMockScope(""))
-			key, err := mapper.GetKey(getDiscoveryRequest())
+			req := getDiscoveryRequest()
+			key, err := mapper.GetKey(transport.NewRequestV2(&req))
 			Expect(expectedKey).To(Equal(key))
 			Expect(err).Should(BeNil())
 		},
@@ -1193,7 +1195,8 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := New(&protoConfig, stats.NewMockScope(""))
-			key, err := mapper.GetKey(getDiscoveryRequest())
+			req := getDiscoveryRequest()
+			key, err := mapper.GetKey(transport.NewRequestV2(&req))
 			Expect(key).To(Equal(""))
 			Expect(err).Should(Equal(fmt.Errorf("Cannot map the input to a key")))
 		},
@@ -1214,7 +1217,8 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := New(&protoConfig, stats.NewMockScope(""))
-			key, err := mapper.GetKey(getDiscoveryRequest())
+			req := getDiscoveryRequest()
+			key, err := mapper.GetKey(transport.NewRequestV2(&req))
 			Expect(key).To(Equal(""))
 			Expect(err.Error()).Should(Equal("error parsing regexp: invalid UTF-8: `\xbd\xb2`"))
 		},
@@ -1243,7 +1247,8 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := New(&protoConfig, stats.NewMockScope(""))
-			key, err := mapper.GetKey(getDiscoveryRequest())
+			req := getDiscoveryRequest()
+			key, err := mapper.GetKey(transport.NewRequestV2(&req))
 			Expect(key).To(Equal(""))
 			Expect(err.Error()).Should(Equal("error parsing regexp: invalid UTF-8: `\xbd\xb2`"))
 		},
@@ -1264,7 +1269,7 @@ var _ = Describe("GetKey", func() {
 				},
 			}
 			mapper := New(&protoConfig, stats.NewMockScope(""))
-			key, err := mapper.GetKey(request)
+			key, err := mapper.GetKey(transport.NewRequestV2(&request))
 			Expect(key).To(Equal(""))
 			Expect(err).Should(Equal(fmt.Errorf(assert)))
 		},
@@ -1274,7 +1279,7 @@ var _ = Describe("GetKey", func() {
 		mapper := New(&KeyerConfiguration{}, stats.NewMockScope(""))
 		request := getDiscoveryRequest()
 		request.TypeUrl = ""
-		key, err := mapper.GetKey(request)
+		key, err := mapper.GetKey(transport.NewRequestV2(&request))
 		Expect(key).To(Equal(""))
 		Expect(err).Should(Equal(fmt.Errorf("typeURL is empty")))
 	})

--- a/internal/app/orchestrator/downstream_test.go
+++ b/internal/app/orchestrator/downstream_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/envoyproxy/xds-relay/internal/app/transport"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,13 +28,13 @@ var (
 func Test_downstreamResponseMap_createChannel(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
 	assert.Equal(t, 0, len(responseMap.responseChannels))
-	responseMap.createChannel(&mockRequest)
+	responseMap.createChannel(transport.NewRequestV2(&mockRequest))
 	assert.Equal(t, 1, len(responseMap.responseChannels))
 }
 
 func Test_downstreamResponseMap_get(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
-	request := &mockRequest
+	request := transport.NewRequestV2(&mockRequest)
 	responseMap.createChannel(request)
 	assert.Equal(t, 1, len(responseMap.responseChannels))
 	if _, ok := responseMap.get(request); !ok {
@@ -43,10 +44,10 @@ func Test_downstreamResponseMap_get(t *testing.T) {
 
 func Test_downstreamResponseMap_delete(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
-	request := &mockRequest
-	request2 := &gcp.Request{
+	request := transport.NewRequestV2(&mockRequest)
+	request2 := transport.NewRequestV2(&gcp.Request{
 		TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
-	}
+	})
 	responseMap.createChannel(request)
 	responseMap.createChannel(request2)
 	assert.Equal(t, 2, len(responseMap.responseChannels))
@@ -67,19 +68,19 @@ func Test_downstreamResponseMap_delete(t *testing.T) {
 
 func Test_downstreamResponseMap_deleteAll(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
-	request := &mockRequest
-	request2 := &gcp.Request{
+	request := transport.NewRequestV2(&mockRequest)
+	request2 := transport.NewRequestV2(&gcp.Request{
 		TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
-	}
-	request3 := &gcp.Request{
+	})
+	request3 := transport.NewRequestV2(&gcp.Request{
 		TypeUrl: "type.googleapis.com/envoy.api.v2.RouteConfiguration",
-	}
+	})
 	responseMap.createChannel(request)
 	responseMap.createChannel(request2)
 	responseMap.createChannel(request3)
 	assert.Equal(t, 3, len(responseMap.responseChannels))
 	responseMap.deleteAll(
-		map[*gcp.Request]bool{
+		map[transport.Request]bool{
 			request:  true,
 			request2: true,
 		},

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -170,7 +170,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 			"request_node", req.GetNode()).Error(ctx, "failed to add watch")
 		metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorRegisterWatch).Inc(1)
 		w := o.downstreamResponseMap.delete(&req)
-		return w.GetChannelV2(), nil
+		return w.GetChannel().(chan gcp.Response), nil
 	}
 	metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchCreated).Inc(1)
 
@@ -227,7 +227,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		}
 	}
 
-	return responseChannel.watch.GetChannelV2(), o.onCancelWatch(aggregatedKey, &req)
+	return responseChannel.watch.GetChannel().(chan gcp.Response), o.onCancelWatch(aggregatedKey, &req)
 }
 
 // Fetch implements the polling method of the config cache using a non-empty request.

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -133,7 +133,7 @@ func New(
 func (o *orchestrator) CreateWatch(r gcp.Request) (chan gcp.Response, func()) {
 	req := transport.NewRequestV2(&r)
 	w, f := o.createWatch(req)
-	return w.GetChannel().(chan gcp.Response), f
+	return w.GetChannel().V2, f
 }
 
 func (o *orchestrator) createWatch(req transport.Request) (transport.Watch, func()) {
@@ -156,7 +156,7 @@ func (o *orchestrator) createWatch(req transport.Request) (transport.Watch, func
 		// TODO (https://github.com/envoyproxy/xds-relay/issues/56). Can we
 		// condense this key but still make it granular enough to uniquely
 		// identify a request?
-		aggregatedKey = fmt.Sprintf("%s%s", unaggregatedPrefix, req.GetRaw())
+		aggregatedKey = fmt.Sprintf("%s%s", unaggregatedPrefix, req.GetRaw().V2)
 	}
 
 	o.logger.With(
@@ -174,7 +174,7 @@ func (o *orchestrator) createWatch(req transport.Request) (transport.Watch, func
 		// If we fail to register the watch, we need to kill this stream by
 		// closing the response channel.
 		o.logger.With("error", err).With("aggregated_key", aggregatedKey).With(
-			"request", req.GetRaw()).Error(ctx, "failed to add watch")
+			"request", req.GetRaw().V2).Error(ctx, "failed to add watch")
 		metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorRegisterWatch).Inc(1)
 		w := o.downstreamResponseMap.delete(req)
 		return w, nil

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -170,7 +170,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 			"request_node", req.GetNode()).Error(ctx, "failed to add watch")
 		metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorRegisterWatch).Inc(1)
 		w := o.downstreamResponseMap.delete(&req)
-		return w.GetCh().(chan gcp.Response), nil
+		return w.GetChannelV2(), nil
 	}
 	metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchCreated).Inc(1)
 
@@ -227,7 +227,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		}
 	}
 
-	return responseChannel.w.GetCh().(chan gcp.Response), o.onCancelWatch(aggregatedKey, &req)
+	return responseChannel.w.GetChannelV2(), o.onCancelWatch(aggregatedKey, &req)
 }
 
 // Fetch implements the polling method of the config cache using a non-empty request.

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -169,8 +169,8 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		o.logger.With("error", err).With("aggregated_key", aggregatedKey).With(
 			"request_node", req.GetNode()).Error(ctx, "failed to add watch")
 		metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorRegisterWatch).Inc(1)
-		closedChannel := o.downstreamResponseMap.delete(&req)
-		return closedChannel, nil
+		w := o.downstreamResponseMap.delete(&req)
+		return w.GetCh().(chan gcp.Response), nil
 	}
 	metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchCreated).Inc(1)
 
@@ -227,7 +227,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		}
 	}
 
-	return responseChannel.channel, o.onCancelWatch(aggregatedKey, &req)
+	return responseChannel.w.GetCh().(chan gcp.Response), o.onCancelWatch(aggregatedKey, &req)
 }
 
 // Fetch implements the polling method of the config cache using a non-empty request.

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -227,7 +227,7 @@ func (o *orchestrator) CreateWatch(req gcp.Request) (chan gcp.Response, func()) 
 		}
 	}
 
-	return responseChannel.w.GetChannelV2(), o.onCancelWatch(aggregatedKey, &req)
+	return responseChannel.watch.GetChannelV2(), o.onCancelWatch(aggregatedKey, &req)
 }
 
 // Fetch implements the polling method of the config cache using a non-empty request.

--- a/internal/app/orchestrator/upstream.go
+++ b/internal/app/orchestrator/upstream.go
@@ -14,7 +14,7 @@ package orchestrator
 import (
 	"sync"
 
-	discovery "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/xds-relay/internal/app/transport"
 )
 
 // upstreamResponseMap is the map of aggregate key to the receive-only upstream
@@ -31,7 +31,7 @@ type upstreamResponseMap struct {
 }
 
 type upstreamResponseChannel struct {
-	response <-chan *discovery.DiscoveryResponse
+	response <-chan transport.Response
 	done     chan bool
 }
 
@@ -51,7 +51,7 @@ func (u *upstreamResponseMap) exists(aggregatedKey string) bool {
 // initializes a done channel to be used during cleanup.
 func (u *upstreamResponseMap) add(
 	aggregatedKey string,
-	responseChannel <-chan *discovery.DiscoveryResponse,
+	responseChannel <-chan transport.Response,
 ) (upstreamResponseChannel, bool) {
 	channel := upstreamResponseChannel{
 		response: responseChannel,

--- a/internal/app/transport/request.go
+++ b/internal/app/transport/request.go
@@ -6,6 +6,11 @@ import (
 	status "google.golang.org/genproto/googleapis/rpc/status"
 )
 
+// RequestVersion holds either one of the v2/v3 DiscoveryRequests
+type RequestVersion struct {
+	V2 *discoveryv2.DiscoveryRequest
+}
+
 // Request is the generic interface to abstract v2 and v3 DiscoveryRequest types
 type Request interface {
 	GetResourceNames() []string
@@ -21,7 +26,7 @@ type Request interface {
 	GetZone() string
 	GetSubZone() string
 	GetResponseNonce() string
-	GetRaw() interface{}
+	GetRaw() *RequestVersion
 	CreateWatch() Watch
 }
 
@@ -103,8 +108,8 @@ func (r *RequestV2) GetSubZone() string {
 }
 
 // GetRaw gets the error details
-func (r *RequestV2) GetRaw() interface{} {
-	return r.r
+func (r *RequestV2) GetRaw() *RequestVersion {
+	return &RequestVersion{V2: r.r}
 }
 
 // GetResponseNonce gets the error details

--- a/internal/app/transport/request.go
+++ b/internal/app/transport/request.go
@@ -1,0 +1,118 @@
+package transport
+
+import (
+	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	status "google.golang.org/genproto/googleapis/rpc/status"
+)
+
+// Request is the generic interface to abstract v2 and v3 DiscoveryRequest types
+type Request interface {
+	GetResourceNames() []string
+	GetTypeURL() string
+	GetVersionInfo() string
+	GetNodeID() string
+	GetNodeMetadata() *structpb.Struct
+	GetCluster() string
+	GetError() *status.Status
+	IsNodeEmpty() bool
+	IsEmptyLocality() bool
+	GetRegion() string
+	GetZone() string
+	GetSubZone() string
+	GetResponseNonce() string
+	GetRaw() interface{}
+	CreateWatch() Watch
+}
+
+// NewRequestV2 creates a Request objects which wraps v2.DiscoveryRequest
+func NewRequestV2(r *discoveryv2.DiscoveryRequest) *RequestV2 {
+	return &RequestV2{
+		r: r,
+	}
+}
+
+var _ Request = &RequestV2{}
+
+// RequestV2 is the v2.DiscoveryRequest impl of Request
+type RequestV2 struct {
+	r *discoveryv2.DiscoveryRequest
+}
+
+// GetResourceNames gets the ResourceNames
+func (r *RequestV2) GetResourceNames() []string {
+	return r.r.GetResourceNames()
+}
+
+// GetVersionInfo gets the version info
+func (r *RequestV2) GetVersionInfo() string {
+	return r.r.GetVersionInfo()
+}
+
+// GetNodeID gets the node id
+func (r *RequestV2) GetNodeID() string {
+	return r.r.GetNode().GetId()
+}
+
+// GetNodeMetadata gets version-agnostic node metadata
+func (r *RequestV2) GetNodeMetadata() *structpb.Struct {
+	if r.r.GetNode() != nil {
+		return r.r.GetNode().GetMetadata()
+	}
+	return nil
+}
+
+// GetCluster gets the cluster name
+func (r *RequestV2) GetCluster() string {
+	return r.r.GetNode().GetCluster()
+}
+
+// GetError gets the error details
+func (r *RequestV2) GetError() *status.Status {
+	return r.r.GetErrorDetail()
+}
+
+// GetTypeURL gets the error details
+func (r *RequestV2) GetTypeURL() string {
+	return r.r.GetTypeUrl()
+}
+
+// IsNodeEmpty gets the error details
+func (r *RequestV2) IsNodeEmpty() bool {
+	return r.r.Node == nil
+}
+
+// IsEmptyLocality gets the error details
+func (r *RequestV2) IsEmptyLocality() bool {
+	return r.r.GetNode().Locality == nil
+}
+
+// GetRegion gets the error details
+func (r *RequestV2) GetRegion() string {
+	return r.r.GetNode().GetLocality().GetRegion()
+}
+
+// GetZone gets the error details
+func (r *RequestV2) GetZone() string {
+	return r.r.GetNode().GetLocality().GetZone()
+}
+
+// GetSubZone gets the error details
+func (r *RequestV2) GetSubZone() string {
+	return r.r.GetNode().GetLocality().GetSubZone()
+}
+
+// GetRaw gets the error details
+func (r *RequestV2) GetRaw() interface{} {
+	return r.r
+}
+
+// GetResponseNonce gets the error details
+func (r *RequestV2) GetResponseNonce() string {
+	return r.r.GetResponseNonce()
+}
+
+// CreateWatch creates a versioned Watch
+func (r *RequestV2) CreateWatch() Watch {
+	return newWatchV2()
+}

--- a/internal/app/transport/response.go
+++ b/internal/app/transport/response.go
@@ -4,13 +4,18 @@ import (
 	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 )
 
+// ResponseVersion holds either one of the v2/v3 DiscoveryRequests
+type ResponseVersion struct {
+	V2 *discoveryv2.DiscoveryResponse
+}
+
 // Response is the generic response interface
 type Response interface {
 	GetPayloadVersion() string
 	GetNonce() string
 	GetTypeURL() string
-	GetRequest() interface{}
-	Get() interface{}
+	GetRequest() *RequestVersion
+	Get() *ResponseVersion
 }
 
 var _ Response = &ResponseV2{}
@@ -45,11 +50,11 @@ func (r *ResponseV2) GetNonce() string {
 }
 
 // GetRequest returns the original request associated with the response
-func (r *ResponseV2) GetRequest() interface{} {
-	return r.req
+func (r *ResponseV2) GetRequest() *RequestVersion {
+	return &RequestVersion{V2: r.req}
 }
 
 // Get returns the original discovery response
-func (r *ResponseV2) Get() interface{} {
-	return r.resp
+func (r *ResponseV2) Get() *ResponseVersion {
+	return &ResponseVersion{V2: r.resp}
 }

--- a/internal/app/transport/response.go
+++ b/internal/app/transport/response.go
@@ -1,0 +1,55 @@
+package transport
+
+import (
+	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+)
+
+// Response is the generic response interface
+type Response interface {
+	GetPayloadVersion() string
+	GetNonce() string
+	GetTypeURL() string
+	GetRequest() interface{}
+	Get() interface{}
+}
+
+var _ Response = &ResponseV2{}
+
+// ResponseV2 is the v2.DiscoveryRequest impl of Response
+type ResponseV2 struct {
+	req  *discoveryv2.DiscoveryRequest
+	resp *discoveryv2.DiscoveryResponse
+}
+
+// NewResponseV2 creates a new instance of wrapped Response
+func NewResponseV2(req *discoveryv2.DiscoveryRequest, resp *discoveryv2.DiscoveryResponse) Response {
+	return &ResponseV2{
+		req:  req,
+		resp: resp,
+	}
+}
+
+// GetPayloadVersion gets the api version
+func (r *ResponseV2) GetPayloadVersion() string {
+	return r.resp.GetVersionInfo()
+}
+
+// GetTypeURL returns the typeUrl for the resource
+func (r *ResponseV2) GetTypeURL() string {
+	return r.resp.GetTypeUrl()
+}
+
+// GetNonce gets the response nonce
+func (r *ResponseV2) GetNonce() string {
+	return r.resp.GetNonce()
+}
+
+// GetRequest returns the original request associated with the response
+func (r *ResponseV2) GetRequest() interface{} {
+	return r.req
+}
+
+// Get returns the original discovery response
+func (r *ResponseV2) Get() interface{} {
+	return r.resp
+}

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -3,52 +3,52 @@ package transport
 import (
 	"fmt"
 
-	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	gcpv2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	gcpv3 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
 // Watch interface abstracts v2 and v3 watches
 type Watch interface {
 	Close()
-	GetChannelV2() chan gcp.Response
+	GetChannelV2() chan gcpv2.Response
 	GetChannelV3() chan gcpv3.Response
 	Send(s interface{}) (bool, error)
 }
 
-var _ Watch = &WatchV2{}
+var _ Watch = &watchV2{}
 
 // WatchV2 is the transport object that takes care of send responses to the xds clients
-type WatchV2 struct {
-	Req *gcp.Request
-	out chan gcp.Response
+type watchV2 struct {
+	Req *gcpv2.Request
+	out chan gcpv2.Response
 }
 
 // NewWatchV2 creates a new watch object
-func NewWatchV2(req *gcp.Request) Watch {
-	return &WatchV2{
+func NewWatchV2(req *gcpv2.Request) Watch {
+	return &watchV2{
 		Req: req,
-		out: make(chan gcp.Response, 1),
+		out: make(chan gcpv2.Response, 1),
 	}
 }
 
 // Close closes the communication with the xds client
-func (w *WatchV2) Close() {
+func (w *watchV2) Close() {
 	close(w.out)
 }
 
 // GetChannelV2 gets the v2 channel used for communication with the xds client
-func (w *WatchV2) GetChannelV2() chan gcp.Response {
+func (w *watchV2) GetChannelV2() chan gcpv2.Response {
 	return w.out
 }
 
 // GetChannelV3 gets the v3 channel used for communication with the xds client
-func (w *WatchV2) GetChannelV3() chan gcpv3.Response {
+func (w *watchV2) GetChannelV3() chan gcpv3.Response {
 	return nil
 }
 
 // Send sends the xds response over wire
-func (w *WatchV2) Send(s interface{}) (bool, error) {
-	resp, ok := s.(gcp.Response)
+func (w *watchV2) Send(s interface{}) (bool, error) {
+	resp, ok := s.(gcpv2.Response)
 	if !ok {
 		return false, fmt.Errorf("payload %s could not be casted to DiscoveryResponse", s)
 	}

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -4,14 +4,12 @@ import (
 	"fmt"
 
 	gcpv2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
-	gcpv3 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
 // Watch interface abstracts v2 and v3 watches
 type Watch interface {
 	Close()
-	GetChannelV2() chan gcpv2.Response
-	GetChannelV3() chan gcpv3.Response
+	GetChannel() interface{}
 	Send(s interface{}) (bool, error)
 }
 
@@ -37,13 +35,8 @@ func (w *watchV2) Close() {
 }
 
 // GetChannelV2 gets the v2 channel used for communication with the xds client
-func (w *watchV2) GetChannelV2() chan gcpv2.Response {
+func (w *watchV2) GetChannel() interface{} {
 	return w.out
-}
-
-// GetChannelV3 gets the v3 channel used for communication with the xds client
-func (w *watchV2) GetChannelV3() chan gcpv3.Response {
-	return nil
 }
 
 // Send sends the xds response over wire

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"fmt"
 
+	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	gcpv2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
@@ -10,21 +11,19 @@ import (
 type Watch interface {
 	Close()
 	GetChannel() interface{}
-	Send(s interface{}) (bool, error)
+	Send(Response) (bool, error)
 }
 
 var _ Watch = &watchV2{}
 
 // WatchV2 is the transport object that takes care of send responses to the xds clients
 type watchV2 struct {
-	Req *gcpv2.Request
 	out chan gcpv2.Response
 }
 
-// NewWatchV2 creates a new watch object
-func NewWatchV2(req *gcpv2.Request) Watch {
+// newWatchV2 creates a new watch object
+func newWatchV2() Watch {
 	return &watchV2{
-		Req: req,
 		out: make(chan gcpv2.Response, 1),
 	}
 }
@@ -40,13 +39,14 @@ func (w *watchV2) GetChannel() interface{} {
 }
 
 // Send sends the xds response over wire
-func (w *watchV2) Send(s interface{}) (bool, error) {
-	resp, ok := s.(gcpv2.Response)
+func (w *watchV2) Send(s Response) (bool, error) {
+	resp, ok := s.(*ResponseV2)
 	if !ok {
 		return false, fmt.Errorf("payload %s could not be casted to DiscoveryResponse", s)
 	}
+
 	select {
-	case w.out <- resp:
+	case w.out <- gcpv2.PassthroughResponse{DiscoveryResponse: resp.resp, Request: *s.GetRequest().(*discoveryv2.DiscoveryRequest)}:
 		return true, nil
 	default:
 		return false, nil

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	gcpv3 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
 // Watch interface abstracts v2 and v3 watches
 type Watch interface {
 	Close()
-	GetCh() interface{}
+	GetChannelV2() chan gcp.Response
+	GetChannelV3() chan gcpv3.Response
 	Send(s interface{}) (bool, error)
 }
 
@@ -34,9 +36,14 @@ func (w *WatchV2) Close() {
 	close(w.out)
 }
 
-// GetCh gets the channel used for communication with the xds client
-func (w *WatchV2) GetCh() interface{} {
+// GetChannelV2 gets the v2 channel used for communication with the xds client
+func (w *WatchV2) GetChannelV2() chan gcp.Response {
 	return w.out
+}
+
+// GetChannelV3 gets the v3 channel used for communication with the xds client
+func (w *WatchV2) GetChannelV3() chan gcpv3.Response {
+	return nil
 }
 
 // Send sends the xds response over wire

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -1,0 +1,54 @@
+package transport
+
+import (
+	"fmt"
+
+	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+)
+
+// Watch interface abstracts v2 and v3 watches
+type Watch interface {
+	Close()
+	GetCh() interface{}
+	Send(s interface{}) (bool, error)
+}
+
+var _ Watch = &WatchV2{}
+
+// WatchV2 is the transport object that takes care of send responses to the xds clients
+type WatchV2 struct {
+	Req *gcp.Request
+	out chan gcp.Response
+}
+
+// NewWatchV2 creates a new watch object
+func NewWatchV2(req *gcp.Request) Watch {
+	return &WatchV2{
+		Req: req,
+		out: make(chan gcp.Response, 1),
+	}
+}
+
+// Close closes the communication with the xds client
+func (w *WatchV2) Close() {
+	close(w.out)
+}
+
+// GetCh gets the channel used for communication with the xds client
+func (w *WatchV2) GetCh() interface{} {
+	return w.out
+}
+
+// Send sends the xds response over wire
+func (w *WatchV2) Send(s interface{}) (bool, error) {
+	resp, ok := s.(gcp.Response)
+	if !ok {
+		return false, fmt.Errorf("payload %s could not be casted to DiscoveryResponse", s)
+	}
+	select {
+	case w.out <- resp:
+		return true, nil
+	default:
+		return false, nil
+	}
+}

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -1,0 +1,81 @@
+package transport
+
+import (
+	"sync"
+	"testing"
+
+	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetChannel(t *testing.T) {
+	w := NewWatchV2(&gcp.Request{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		_, more := <-w.GetCh().(chan gcp.Response)
+		assert.False(t, more)
+		wg.Done()
+	}()
+
+	w.Close()
+	wg.Wait()
+}
+
+func TestSendSuccessful(t *testing.T) {
+	w := NewWatchV2(&gcp.Request{})
+	resp := gcp.RawResponse{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		got, more := <-w.GetCh().(chan gcp.Response)
+		assert.True(t, more)
+		assert.Equal(t, resp, got)
+		wg.Done()
+	}()
+	go func() {
+		ok, err := w.Send(resp)
+		assert.True(t, ok)
+		assert.Nil(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func TestSendCastFailure(t *testing.T) {
+	w := NewWatchV2(&gcp.Request{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		ok, err := w.Send("")
+		assert.False(t, ok)
+		assert.NotNil(t, err)
+		wg.Done()
+	}()
+	wg.Wait()
+}
+
+func TestSendFalseWhenBlocked(t *testing.T) {
+	w := NewWatchV2(&gcp.Request{})
+	var wg sync.WaitGroup
+	resp := gcp.RawResponse{}
+	wg.Add(2)
+	// We perform 2 sends with no receive on w.Out .
+	// One of the send gets blocked because of no recipient.
+	// The second send goes goes to default case due to channel full.
+	// The second send closes the channel when blocked.
+	// The closed channel terminates the blocked send to exit the test case.
+	go sendWithCloseChannelOnFailure(t, w, &wg, resp)
+	go sendWithCloseChannelOnFailure(t, w, &wg, resp)
+
+	wg.Wait()
+}
+
+func sendWithCloseChannelOnFailure(t *testing.T, w Watch, wg *sync.WaitGroup, r interface{}) {
+	ok, err := w.Send(r)
+	assert.Nil(t, err)
+	if !ok {
+		w.Close()
+	}
+	wg.Done()
+}

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -13,7 +13,7 @@ func TestGetChannel(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		_, more := <-w.GetCh().(chan gcp.Response)
+		_, more := <-w.GetChannelV2()
 		assert.False(t, more)
 		wg.Done()
 	}()
@@ -28,7 +28,7 @@ func TestSendSuccessful(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		got, more := <-w.GetCh().(chan gcp.Response)
+		got, more := <-w.GetChannelV2()
 		assert.True(t, more)
 		assert.Equal(t, resp, got)
 		wg.Done()

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -13,7 +13,7 @@ func TestGetChannel(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		_, more := <-w.GetChannelV2()
+		_, more := <-w.GetChannel().(chan gcp.Response)
 		assert.False(t, more)
 		wg.Done()
 	}()
@@ -28,7 +28,7 @@ func TestSendSuccessful(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		got, more := <-w.GetChannelV2()
+		got, more := <-w.GetChannel().(chan gcp.Response)
 		assert.True(t, more)
 		assert.Equal(t, resp, got)
 		wg.Done()

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -15,7 +15,7 @@ func TestGetChannel(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		_, more := <-w.GetChannel().(chan gcp.Response)
+		_, more := <-w.GetChannel().V2
 		assert.False(t, more)
 		wg.Done()
 	}()
@@ -32,7 +32,7 @@ func TestSendSuccessful(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
-		got, more := <-w.GetChannel().(chan gcp.Response)
+		got, more := <-w.GetChannel().V2
 		assert.True(t, more)
 		assert.Equal(t, cache.PassthroughResponse{DiscoveryResponse: discoveryResponse, Request: *discoveryRequest}, got)
 		wg.Done()
@@ -101,10 +101,10 @@ func (r *mockResponse) GetNonce() string {
 	return ""
 }
 
-func (r *mockResponse) GetRequest() interface{} {
-	return nil
+func (r *mockResponse) GetRequest() *RequestVersion {
+	return &RequestVersion{}
 }
 
-func (r *mockResponse) Get() interface{} {
-	return nil
+func (r *mockResponse) Get() *ResponseVersion {
+	return &ResponseVersion{}
 }

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -195,7 +195,7 @@ func send(
 			// Ref: https://github.com/grpc/grpc-go/issues/1229#issuecomment-302755717
 			// Call SendMsg in a timeout because it can block in some cases.
 			err := util.DoWithTimeout(ctx, func() error {
-				return stream.SendMsg(request)
+				return stream.SendMsg(request.GetRaw().V2)
 			}, callOptions.Timeout)
 			if err != nil {
 				handleError(ctx, logger, "Error in SendMsg", cancelFunc, err)

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -189,7 +189,7 @@ func send(
 			if !ok {
 				return
 			}
-			discoveryRequest := request.GetRaw().(*v2.DiscoveryRequest)
+			discoveryRequest := request.GetRaw().V2
 			discoveryRequest.ResponseNonce = sig.nonce
 			discoveryRequest.VersionInfo = sig.version
 			// Ref: https://github.com/grpc/grpc-go/issues/1229#issuecomment-302755717
@@ -238,7 +238,7 @@ func recv(
 		case <-ctx.Done():
 			break
 		default:
-			response <- transport.NewResponseV2(request.GetRaw().(*v2.DiscoveryRequest), resp)
+			response <- transport.NewResponseV2(request.GetRaw().V2, resp)
 			signal <- &version{version: resp.GetVersionInfo(), nonce: resp.GetNonce()}
 		}
 	}

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -88,7 +88,7 @@ func TestOpenStreamShouldSendTheFirstRequestToOriginServer(t *testing.T) {
 		}))
 	<-wait
 	assert.NotNil(t, message)
-	assert.Equal(t, message.GetRaw().(*v2.DiscoveryRequest).GetNode(), node)
+	assert.Equal(t, message.GetRaw().V2.GetNode(), node)
 	assert.Equal(t, message.GetTypeURL(), upstream.ListenerTypeURL)
 	done()
 }
@@ -126,7 +126,7 @@ func TestOpenStreamShouldSendTheResponseOnTheChannel(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, resp)
 	val := <-resp
-	assert.Equal(t, val.Get(), response)
+	assert.Equal(t, val.Get().V2, response)
 	done()
 }
 

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -62,7 +62,7 @@ func TestOpenStreamShouldReturnNonEmptyResponseChannel(t *testing.T) {
 }
 
 func TestOpenStreamShouldSendTheFirstRequestToOriginServer(t *testing.T) {
-	var message transport.Request
+	var message *v2.DiscoveryRequest
 	responseChan := make(chan *v2.DiscoveryResponse)
 	wait := make(chan bool)
 	client := upstream.NewMock(
@@ -74,7 +74,7 @@ func TestOpenStreamShouldSendTheFirstRequestToOriginServer(t *testing.T) {
 		responseChan,
 		responseChan,
 		func(m interface{}) error {
-			message = m.(transport.Request)
+			message = m.(*v2.DiscoveryRequest)
 			wait <- true
 			return nil
 		},
@@ -88,8 +88,8 @@ func TestOpenStreamShouldSendTheFirstRequestToOriginServer(t *testing.T) {
 		}))
 	<-wait
 	assert.NotNil(t, message)
-	assert.Equal(t, message.GetRaw().V2.GetNode(), node)
-	assert.Equal(t, message.GetTypeURL(), upstream.ListenerTypeURL)
+	assert.Equal(t, message.GetNode(), node)
+	assert.Equal(t, message.GetTypeUrl(), upstream.ListenerTypeURL)
 	done()
 }
 
@@ -135,7 +135,7 @@ func TestOpenStreamShouldSendTheNextRequestWithUpdatedVersionAndNonce(t *testing
 	lastAppliedVersion := ""
 	index := 0
 	client := createMockClientWithResponse(time.Second, responseChan, func(m interface{}) error {
-		message := m.(transport.Request)
+		message := m.(*v2.DiscoveryRequest)
 
 		assert.Equal(t, message.GetVersionInfo(), lastAppliedVersion)
 		assert.Equal(t, message.GetResponseNonce(), lastAppliedVersion)


### PR DESCRIPTION
Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>

As an initial step to introduce v3 api, we need to separate the logic of orchestrator such that there are no dependencies on v2/v3 DiscoveryRequest.
This PR removes the dependency on the response channels and creates a watch interface to send responses.

Next PR: abstract DiscoveryRequest from orchestrator and mapper.