### PR TITLE
Abstract stream

### DIFF
--- a/integration/upstream_client_test.go
+++ b/integration/upstream_client_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/envoyproxy/xds-relay/internal/pkg/stats"
 
 	gcpcachev2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	gcpserverv2 "github.com/envoyproxy/go-control-plane/pkg/server/v2"
 	gcpserverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	gcptest "github.com/envoyproxy/go-control-plane/pkg/test"
@@ -160,13 +161,13 @@ func TestClientContextCancellationShouldCloseAllResponseChannels(t *testing.T) {
 		stats.NewMockScope("mock"),
 	)
 	respCh1, _, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
-		TypeUrl: upstream.ClusterTypeURL,
+		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
 	}))
 	respCh2, _, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
-		TypeUrl: upstream.ClusterTypeURL,
+		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
@@ -222,7 +223,7 @@ func setup(
 	}
 
 	respCh, shutdown, err := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
-		TypeUrl: upstream.ClusterTypeURL,
+		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
 		},

--- a/internal/app/transport/request.go
+++ b/internal/app/transport/request.go
@@ -28,8 +28,6 @@ type Request interface {
 	GetResponseNonce() string
 	GetRaw() *RequestVersion
 	CreateWatch() Watch
-	UpdateVersion(version string)
-	UpdateNonce(nonce string)
 }
 
 // NewRequestV2 creates a Request objects which wraps v2.DiscoveryRequest
@@ -122,14 +120,4 @@ func (r *RequestV2) GetResponseNonce() string {
 // CreateWatch creates a versioned Watch
 func (r *RequestV2) CreateWatch() Watch {
 	return newWatchV2()
-}
-
-// UpdateVersion overrides the versioninfo
-func (r *RequestV2) UpdateVersion(version string) {
-	r.r.VersionInfo = version
-}
-
-// UpdateNonce overrides the versioninfo
-func (r *RequestV2) UpdateNonce(nonce string) {
-	r.r.ResponseNonce = nonce
 }

--- a/internal/app/transport/request.go
+++ b/internal/app/transport/request.go
@@ -28,6 +28,8 @@ type Request interface {
 	GetResponseNonce() string
 	GetRaw() *RequestVersion
 	CreateWatch() Watch
+	UpdateVersion(version string)
+	UpdateNonce(nonce string)
 }
 
 // NewRequestV2 creates a Request objects which wraps v2.DiscoveryRequest
@@ -120,4 +122,14 @@ func (r *RequestV2) GetResponseNonce() string {
 // CreateWatch creates a versioned Watch
 func (r *RequestV2) CreateWatch() Watch {
 	return newWatchV2()
+}
+
+// UpdateVersion overrides the versioninfo
+func (r *RequestV2) UpdateVersion(version string) {
+	r.r.VersionInfo = version
+}
+
+// UpdateNonce overrides the versioninfo
+func (r *RequestV2) UpdateNonce(nonce string) {
+	r.r.ResponseNonce = nonce
 }

--- a/internal/app/transport/response.go
+++ b/internal/app/transport/response.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/golang/protobuf/ptypes/any"
 )
 
 // ResponseVersion holds either one of the v2/v3 DiscoveryRequests
@@ -16,6 +17,8 @@ type Response interface {
 	GetTypeURL() string
 	GetRequest() *RequestVersion
 	Get() *ResponseVersion
+	GetVersionInfo() string
+	GetResources() []*any.Any
 }
 
 var _ Response = &ResponseV2{}
@@ -57,4 +60,14 @@ func (r *ResponseV2) GetRequest() *RequestVersion {
 // Get returns the original discovery response
 func (r *ResponseV2) Get() *ResponseVersion {
 	return &ResponseVersion{V2: r.resp}
+}
+
+// GetVersionInfo returns the original discovery response
+func (r *ResponseV2) GetVersionInfo() string {
+	return r.resp.GetVersionInfo()
+}
+
+// GetResources returns the original discovery response
+func (r *ResponseV2) GetResources() []*any.Any {
+	return r.resp.GetResources()
 }

--- a/internal/app/transport/stream.go
+++ b/internal/app/transport/stream.go
@@ -1,0 +1,44 @@
+package transport
+
+import (
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"google.golang.org/grpc"
+)
+
+// Stream abstracts the grpc client stream and DiscoveryRequest/Response
+type Stream interface {
+	SendMsg() error
+	RecvMsg() (Response, error)
+	CloseSend() error
+}
+
+var _ Stream = &streamv2{}
+
+type streamv2 struct {
+	grpcClientStream grpc.ClientStream
+	initialRequest   Request
+}
+
+// NewStreamV2 creates a new wrapped transport stream
+func NewStreamV2(clientStream grpc.ClientStream, req Request) Stream {
+	return &streamv2{
+		grpcClientStream: clientStream,
+		initialRequest:   req,
+	}
+}
+
+func (s *streamv2) SendMsg() error {
+	return s.grpcClientStream.SendMsg(s.initialRequest.GetRaw().V2)
+}
+
+func (s *streamv2) RecvMsg() (Response, error) {
+	resp := new(v2.DiscoveryResponse)
+	if err := s.grpcClientStream.RecvMsg(resp); err != nil {
+		return nil, err
+	}
+	return NewResponseV2(s.initialRequest.GetRaw().V2, resp), nil
+}
+
+func (s *streamv2) CloseSend() error {
+	return s.grpcClientStream.CloseSend()
+}

--- a/internal/app/transport/stream.go
+++ b/internal/app/transport/stream.go
@@ -7,7 +7,7 @@ import (
 
 // Stream abstracts the grpc client stream and DiscoveryRequest/Response
 type Stream interface {
-	SendMsg() error
+	SendMsg(version string, nonce string) error
 	RecvMsg() (Response, error)
 	CloseSend() error
 }
@@ -27,8 +27,11 @@ func NewStreamV2(clientStream grpc.ClientStream, req Request) Stream {
 	}
 }
 
-func (s *streamv2) SendMsg() error {
-	return s.grpcClientStream.SendMsg(s.initialRequest.GetRaw().V2)
+func (s *streamv2) SendMsg(version string, nonce string) error {
+	msg := s.initialRequest.GetRaw().V2
+	msg.VersionInfo = version
+	msg.ResponseNonce = nonce
+	return s.grpcClientStream.SendMsg(msg)
 }
 
 func (s *streamv2) RecvMsg() (Response, error) {

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -7,6 +7,7 @@ import (
 	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,4 +108,12 @@ func (r *mockResponse) GetRequest() *RequestVersion {
 
 func (r *mockResponse) Get() *ResponseVersion {
 	return &ResponseVersion{}
+}
+
+func (r *mockResponse) GetVersionInfo() string {
+	return ""
+}
+
+func (r *mockResponse) GetResources() []*any.Any {
+	return nil
 }

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -195,12 +195,10 @@ func send(
 			if !ok {
 				return
 			}
-			request.UpdateNonce(sig.nonce)
-			request.UpdateVersion(sig.version)
 			// Ref: https://github.com/grpc/grpc-go/issues/1229#issuecomment-302755717
 			// Call SendMsg in a timeout because it can block in some cases.
 			err := util.DoWithTimeout(ctx, func() error {
-				return stream.SendMsg()
+				return stream.SendMsg(sig.version, sig.nonce)
 			}, callOptions.Timeout)
 			if err != nil {
 				handleError(ctx, logger, "Error in SendMsg", cancelFunc, err)

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -226,9 +226,8 @@ func recv(
 	stream transport.Stream,
 	signal chan *version) {
 	for {
-		var resp transport.Response
-		var err error
-		if resp, err = stream.RecvMsg(); err != nil {
+		resp, err := stream.RecvMsg()
+		if err != nil {
 			handleError(ctx, logger, "Error in RecvMsg", cancelFunc, err)
 			break
 		}

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/envoyproxy/xds-relay/internal/app/transport"
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/envoyproxy/xds-relay/internal/pkg/log"
 	"github.com/envoyproxy/xds-relay/internal/pkg/util"
 	"github.com/uber-go/tally"
@@ -17,13 +18,13 @@ import (
 
 const (
 	// ListenerTypeURL is the resource url for listener
-	ListenerTypeURL = "type.googleapis.com/envoy.api.v2.Listener"
+	ListenerTypeURL = resource.ListenerType
 	// ClusterTypeURL is the resource url for cluster
-	ClusterTypeURL = "type.googleapis.com/envoy.api.v2.Cluster"
+	ClusterTypeURL = resource.ClusterType
 	// EndpointTypeURL is the resource url for endpoints
-	EndpointTypeURL = "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
+	EndpointTypeURL = resource.EndpointType
 	// RouteTypeURL is the resource url for route
-	RouteTypeURL = "type.googleapis.com/envoy.api.v2.RouteConfiguration"
+	RouteTypeURL = resource.RouteType
 )
 
 // UnsupportedResourceError is a custom error for unsupported typeURL
@@ -122,22 +123,27 @@ func New(
 func (m *client) OpenStream(request transport.Request) (<-chan transport.Response, func(), error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	var (
-		stream grpc.ClientStream
+		s      grpc.ClientStream
+		stream transport.Stream
 		err    error
 		scope  tally.Scope
 	)
 	switch request.GetTypeURL() {
 	case ListenerTypeURL:
-		stream, err = m.ldsClient.StreamListeners(ctx)
+		s, err = m.ldsClient.StreamListeners(ctx)
+		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamLDS)
 	case ClusterTypeURL:
-		stream, err = m.cdsClient.StreamClusters(ctx)
+		s, err = m.cdsClient.StreamClusters(ctx)
+		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamCDS)
 	case RouteTypeURL:
-		stream, err = m.rdsClient.StreamRoutes(ctx)
+		s, err = m.rdsClient.StreamRoutes(ctx)
+		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamRDS)
 	case EndpointTypeURL:
-		stream, err = m.edsClient.StreamEndpoints(ctx)
+		s, err = m.edsClient.StreamEndpoints(ctx)
+		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamEDS)
 	default:
 		defer cancel()
@@ -160,7 +166,7 @@ func (m *client) OpenStream(request transport.Request) (<-chan transport.Respons
 	response := make(chan transport.Response)
 
 	go send(ctx, m.logger, cancel, request, stream, signal, m.callOptions)
-	go recv(ctx, cancel, m.logger, request, response, stream, signal)
+	go recv(ctx, cancel, m.logger, response, stream, signal)
 
 	m.logger.With("request_type", request.GetTypeURL()).Info(ctx, "stream opened")
 
@@ -180,7 +186,7 @@ func send(
 	logger log.Logger,
 	cancelFunc context.CancelFunc,
 	request transport.Request,
-	stream grpc.ClientStream,
+	stream transport.Stream,
 	signal chan *version,
 	callOptions CallOptions) {
 	for {
@@ -189,13 +195,12 @@ func send(
 			if !ok {
 				return
 			}
-			discoveryRequest := request.GetRaw().V2
-			discoveryRequest.ResponseNonce = sig.nonce
-			discoveryRequest.VersionInfo = sig.version
+			request.UpdateNonce(sig.nonce)
+			request.UpdateVersion(sig.version)
 			// Ref: https://github.com/grpc/grpc-go/issues/1229#issuecomment-302755717
 			// Call SendMsg in a timeout because it can block in some cases.
 			err := util.DoWithTimeout(ctx, func() error {
-				return stream.SendMsg(request.GetRaw().V2)
+				return stream.SendMsg()
 			}, callOptions.Timeout)
 			if err != nil {
 				handleError(ctx, logger, "Error in SendMsg", cancelFunc, err)
@@ -219,26 +224,26 @@ func recv(
 	ctx context.Context,
 	cancelFunc context.CancelFunc,
 	logger log.Logger,
-	request transport.Request,
 	response chan transport.Response,
-	stream grpc.ClientStream,
+	stream transport.Stream,
 	signal chan *version) {
 	for {
-		resp := new(v2.DiscoveryResponse)
-		if err := stream.RecvMsg(resp); err != nil {
+		var resp transport.Response
+		var err error
+		if resp, err = stream.RecvMsg(); err != nil {
 			handleError(ctx, logger, "Error in RecvMsg", cancelFunc, err)
 			break
 		}
 		logger.With(
 			"response_version", resp.GetVersionInfo(),
-			"response_type", resp.GetTypeUrl(),
+			"response_type", resp.GetTypeURL(),
 			"resource_length", len(resp.GetResources()),
 		).Debug(context.Background(), "received message")
 		select {
 		case <-ctx.Done():
 			break
 		default:
-			response <- transport.NewResponseV2(request.GetRaw().V2, resp)
+			response <- resp
 			signal <- &version{version: resp.GetVersionInfo(), nonce: resp.GetNonce()}
 		}
 	}

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -16,17 +16,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-const (
-	// ListenerTypeURL is the resource url for listener
-	ListenerTypeURL = resource.ListenerType
-	// ClusterTypeURL is the resource url for cluster
-	ClusterTypeURL = resource.ClusterType
-	// EndpointTypeURL is the resource url for endpoints
-	EndpointTypeURL = resource.EndpointType
-	// RouteTypeURL is the resource url for route
-	RouteTypeURL = resource.RouteType
-)
-
 // UnsupportedResourceError is a custom error for unsupported typeURL
 type UnsupportedResourceError struct {
 	TypeURL string
@@ -129,19 +118,19 @@ func (m *client) OpenStream(request transport.Request) (<-chan transport.Respons
 		scope  tally.Scope
 	)
 	switch request.GetTypeURL() {
-	case ListenerTypeURL:
+	case resource.ListenerType:
 		s, err = m.ldsClient.StreamListeners(ctx)
 		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamLDS)
-	case ClusterTypeURL:
+	case resource.ClusterType:
 		s, err = m.cdsClient.StreamClusters(ctx)
 		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamCDS)
-	case RouteTypeURL:
+	case resource.RouteType:
 		s, err = m.rdsClient.StreamRoutes(ctx)
 		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamRDS)
-	case EndpointTypeURL:
+	case resource.EndpointType:
 		s, err = m.edsClient.StreamEndpoints(ctx)
 		stream = transport.NewStreamV2(s, request)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamEDS)

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"github.com/envoyproxy/go-control-plane/pkg/resource/v2"
 	"github.com/envoyproxy/xds-relay/internal/app/transport"
 	"github.com/envoyproxy/xds-relay/internal/app/upstream"
 	"github.com/stretchr/testify/assert"
@@ -30,10 +31,10 @@ func TestOpenStreamShouldReturnErrorOnStreamCreationFailure(t *testing.T) {
 	client := createMockClientWithError()
 
 	typeURLs := []string{
-		upstream.ListenerTypeURL,
-		upstream.ClusterTypeURL,
-		upstream.RouteTypeURL,
-		upstream.EndpointTypeURL,
+		resource.ListenerType,
+		resource.ClusterType,
+		resource.RouteType,
+		resource.EndpointType,
 	}
 	for _, typeURL := range typeURLs {
 		t.Run(typeURL, func(t *testing.T) {
@@ -53,7 +54,7 @@ func TestOpenStreamShouldReturnNonEmptyResponseChannel(t *testing.T) {
 
 	respCh, done, err := client.OpenStream(
 		transport.NewRequestV2(&v2.DiscoveryRequest{
-			TypeUrl: upstream.ListenerTypeURL,
+			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
 		}))
 	assert.NotNil(t, respCh)
@@ -83,13 +84,13 @@ func TestOpenStreamShouldSendTheFirstRequestToOriginServer(t *testing.T) {
 	node := &core.Node{}
 	_, done, _ := client.OpenStream(
 		transport.NewRequestV2(&v2.DiscoveryRequest{
-			TypeUrl: upstream.ListenerTypeURL,
+			TypeUrl: resource.ListenerType,
 			Node:    node,
 		}))
 	<-wait
 	assert.NotNil(t, message)
 	assert.Equal(t, message.GetNode(), node)
-	assert.Equal(t, message.GetTypeUrl(), upstream.ListenerTypeURL)
+	assert.Equal(t, message.GetTypeUrl(), resource.ListenerType)
 	done()
 }
 
@@ -102,7 +103,7 @@ func TestOpenStreamShouldSendErrorIfSendFails(t *testing.T) {
 
 	resp, done, _ := client.OpenStream(
 		transport.NewRequestV2(&v2.DiscoveryRequest{
-			TypeUrl: upstream.ListenerTypeURL,
+			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
 		}))
 	_, more := <-resp
@@ -120,7 +121,7 @@ func TestOpenStreamShouldSendTheResponseOnTheChannel(t *testing.T) {
 
 	resp, done, err := client.OpenStream(
 		transport.NewRequestV2(&v2.DiscoveryRequest{
-			TypeUrl: upstream.ListenerTypeURL,
+			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
 		}))
 	assert.Nil(t, err)
@@ -143,7 +144,7 @@ func TestOpenStreamShouldSendTheNextRequestWithUpdatedVersionAndNonce(t *testing
 		response := &v2.DiscoveryResponse{
 			VersionInfo: strconv.Itoa(index),
 			Nonce:       strconv.Itoa(index),
-			TypeUrl:     upstream.ListenerTypeURL,
+			TypeUrl:     resource.ListenerType,
 		}
 		lastAppliedVersion = strconv.Itoa(index)
 		index++
@@ -153,7 +154,7 @@ func TestOpenStreamShouldSendTheNextRequestWithUpdatedVersionAndNonce(t *testing
 
 	resp, done, err := client.OpenStream(
 		transport.NewRequestV2(&v2.DiscoveryRequest{
-			TypeUrl: upstream.ListenerTypeURL,
+			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
 		}))
 	assert.Nil(t, err)
@@ -178,7 +179,7 @@ func TestOpenStreamShouldSendErrorWhenSendMsgBlocks(t *testing.T) {
 	})
 
 	resp, done, err := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
-		TypeUrl: upstream.ListenerTypeURL,
+		TypeUrl: resource.ListenerType,
 		Node:    &core.Node{},
 	}))
 	assert.Nil(t, err)


### PR DESCRIPTION
Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>

The stream send and recv depended on the V2 references. Abstracting stream such that the upstream/client.go does not depend on V2 protos.