### PR TITLE
Evict cache on upstream failure

### DIFF
--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -280,11 +280,11 @@ func (o *orchestrator) watchUpstream(
 		case x, more := <-responseChannel:
 			if !more {
 				// A problem occurred fetching the response upstream, log retry.
-				// TODO implement retry/back-off logic on error scenario.
-				// https://github.com/envoyproxy/xds-relay/issues/68
 				o.logger.With("aggregated_key", aggregatedKey).Error(ctx, "upstream error")
 				metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorUpstreamFailure).Inc(1)
 
+				// TODO implement retry/back-off logic on error scenario.
+				// https://github.com/envoyproxy/xds-relay/issues/68
 				f, err := o.cache.Fetch(aggregatedKey)
 				if err == nil {
 					o.onCacheEvicted(aggregatedKey, *f)

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -284,6 +284,9 @@ func (o *orchestrator) watchUpstream(
 				// https://github.com/envoyproxy/xds-relay/issues/68
 				o.logger.With("aggregated_key", aggregatedKey).Error(ctx, "upstream error")
 				metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorUpstreamFailure).Inc(1)
+
+				f, _ := o.cache.Fetch(aggregatedKey)
+				o.onCacheEvicted(aggregatedKey, *f)
 				return
 			}
 			// Cache the response.

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -285,8 +285,11 @@ func (o *orchestrator) watchUpstream(
 				o.logger.With("aggregated_key", aggregatedKey).Error(ctx, "upstream error")
 				metrics.OrchestratorWatchErrorsSubscope(o.scope, aggregatedKey).Counter(metrics.ErrorUpstreamFailure).Inc(1)
 
-				f, _ := o.cache.Fetch(aggregatedKey)
-				o.onCacheEvicted(aggregatedKey, *f)
+				f, err := o.cache.Fetch(aggregatedKey)
+				if err == nil {
+					o.onCacheEvicted(aggregatedKey, *f)
+				}
+
 				return
 			}
 			// Cache the response.

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -387,7 +387,6 @@ func TestUpstreamFailure(t *testing.T) {
 	assert.NoError(t, err)
 
 	respChannel, cancelWatch := orchestrator.CreateWatch(transport.NewRequestV2(&req))
-	countersSnapshot := mockScope.Snapshot().Counters()
 
 	// close upstream channel. This happens when upstream client receives an error
 	close(upstreamResponseChannel)
@@ -402,7 +401,7 @@ func TestUpstreamFailure(t *testing.T) {
 
 	cancelWatch()
 
-	countersSnapshot = mockScope.Snapshot().Counters()
+	countersSnapshot := mockScope.Snapshot().Counters()
 	assert.EqualValues(
 		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.errors.upstream+key=%v", aggregatedKey)].Value())
 	assert.EqualValues(

--- a/internal/app/transport/streamv2.go
+++ b/internal/app/transport/streamv2.go
@@ -21,6 +21,7 @@ func NewStreamV2(clientStream grpc.ClientStream, req Request, l log.Logger) Stre
 	return &streamv2{
 		grpcClientStream: clientStream,
 		initialRequest:   req,
+		logger:           l,
 	}
 }
 

--- a/internal/app/transport/streamv2.go
+++ b/internal/app/transport/streamv2.go
@@ -32,6 +32,7 @@ func (s *streamv2) SendMsg(version string, nonce string) error {
 	s.logger.With(
 		"request_type", msg.GetTypeUrl(),
 		"request_version", msg.GetVersionInfo(),
+		"request_resource_names", msg.ResourceNames,
 	).Debug(context.Background(), "sent message")
 	return s.grpcClientStream.SendMsg(msg)
 }

--- a/internal/app/transport/streamv2.go
+++ b/internal/app/transport/streamv2.go
@@ -21,7 +21,7 @@ func NewStreamV2(clientStream grpc.ClientStream, req Request, l log.Logger) Stre
 	return &streamv2{
 		grpcClientStream: clientStream,
 		initialRequest:   req,
-		logger:           l,
+		logger:           l.Named("stream"),
 	}
 }
 
@@ -42,9 +42,8 @@ func (s *streamv2) RecvMsg() (Response, error) {
 		return nil, err
 	}
 	s.logger.With(
-		"request_type", resp.GetTypeUrl(),
-		"request_version", resp.GetVersionInfo(),
 		"response_type", resp.GetTypeUrl(),
+		"request_version", resp.GetVersionInfo(),
 		"resource_length", len(resp.GetResources()),
 	).Debug(context.Background(), "received message")
 	return NewResponseV2(s.initialRequest.GetRaw().V2, resp), nil

--- a/internal/app/transport/streamv2.go
+++ b/internal/app/transport/streamv2.go
@@ -44,6 +44,7 @@ func (s *streamv2) RecvMsg() (Response, error) {
 	s.logger.With(
 		"request_type", resp.GetTypeUrl(),
 		"request_version", resp.GetVersionInfo(),
+		"response_type", resp.GetTypeUrl(),
 		"resource_length", len(resp.GetResources()),
 	).Debug(context.Background(), "received message")
 	return NewResponseV2(s.initialRequest.GetRaw().V2, resp), nil

--- a/internal/app/transport/streamv3.go
+++ b/internal/app/transport/streamv3.go
@@ -32,7 +32,7 @@ func (s *streamv3) SendMsg(version string, nonce string) error {
 	s.logger.With(
 		"request_type", msg.GetTypeUrl(),
 		"request_version", msg.GetVersionInfo(),
-		"request_msg", msg.ResourceNames,
+		"request_resource_names", msg.ResourceNames,
 	).Debug(context.Background(), "sent message")
 
 	return s.grpcClientStream.SendMsg(msg)

--- a/internal/app/transport/streamv3.go
+++ b/internal/app/transport/streamv3.go
@@ -1,7 +1,10 @@
 package transport
 
 import (
+	"context"
+
 	v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	"github.com/envoyproxy/xds-relay/internal/pkg/log"
 	"google.golang.org/grpc"
 )
 
@@ -10,10 +13,11 @@ var _ Stream = &streamv3{}
 type streamv3 struct {
 	grpcClientStream grpc.ClientStream
 	initialRequest   Request
+	logger           log.Logger
 }
 
 // NewStreamV3 creates a new wrapped transport stream
-func NewStreamV3(clientStream grpc.ClientStream, req Request) Stream {
+func NewStreamV3(clientStream grpc.ClientStream, req Request, l log.Logger) Stream {
 	return &streamv3{
 		grpcClientStream: clientStream,
 		initialRequest:   req,
@@ -24,6 +28,11 @@ func (s *streamv3) SendMsg(version string, nonce string) error {
 	msg := s.initialRequest.GetRaw().V3
 	msg.VersionInfo = version
 	msg.ResponseNonce = nonce
+	s.logger.With(
+		"request_type", msg.GetTypeUrl(),
+		"request_version", msg.GetVersionInfo(),
+	).Debug(context.Background(), "sent message")
+
 	return s.grpcClientStream.SendMsg(msg)
 }
 

--- a/internal/app/transport/streamv3.go
+++ b/internal/app/transport/streamv3.go
@@ -21,6 +21,7 @@ func NewStreamV3(clientStream grpc.ClientStream, req Request, l log.Logger) Stre
 	return &streamv3{
 		grpcClientStream: clientStream,
 		initialRequest:   req,
+		logger:           l,
 	}
 }
 

--- a/internal/app/transport/streamv3.go
+++ b/internal/app/transport/streamv3.go
@@ -42,6 +42,11 @@ func (s *streamv3) RecvMsg() (Response, error) {
 	if err := s.grpcClientStream.RecvMsg(resp); err != nil {
 		return nil, err
 	}
+	s.logger.With(
+		"request_type", resp.GetTypeUrl(),
+		"request_version", resp.GetVersionInfo(),
+		"resource_length", len(resp.GetResources()),
+	).Debug(context.Background(), "received message")
 	return NewResponseV3(s.initialRequest.GetRaw().V3, resp), nil
 }
 

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -138,35 +138,35 @@ func (m *client) OpenStream(request transport.Request) (<-chan transport.Respons
 	switch request.GetTypeURL() {
 	case resource.ListenerType:
 		s, err = m.ldsClient.StreamListeners(ctx)
-		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV2(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamLDS)
 	case resource.ClusterType:
 		s, err = m.cdsClient.StreamClusters(ctx)
-		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV2(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamCDS)
 	case resource.RouteType:
 		s, err = m.rdsClient.StreamRoutes(ctx)
-		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV2(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamRDS)
 	case resource.EndpointType:
 		s, err = m.edsClient.StreamEndpoints(ctx)
-		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV2(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamEDS)
 	case resourcev3.ListenerType:
 		s, err = m.ldsClientV3.StreamListeners(ctx)
-		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV3(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamLDS)
 	case resourcev3.ClusterType:
 		s, err = m.cdsClientV3.StreamClusters(ctx)
-		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV3(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamCDS)
 	case resourcev3.RouteType:
 		s, err = m.rdsClientV3.StreamRoutes(ctx)
-		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV3(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamRDS)
 	case resourcev3.EndpointType:
 		s, err = m.edsClientV3.StreamEndpoints(ctx)
-		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
+		stream = transport.NewStreamV3(s, request, m.logger)
 		scope = m.scope.SubScope(metrics.ScopeUpstreamEDS)
 	default:
 		defer cancel()

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -138,35 +138,35 @@ func (m *client) OpenStream(request transport.Request) (<-chan transport.Respons
 	switch request.GetTypeURL() {
 	case resource.ListenerType:
 		s, err = m.ldsClient.StreamListeners(ctx)
-		stream = transport.NewStreamV2(s, request)
+		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamLDS)
 	case resource.ClusterType:
 		s, err = m.cdsClient.StreamClusters(ctx)
-		stream = transport.NewStreamV2(s, request)
+		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamCDS)
 	case resource.RouteType:
 		s, err = m.rdsClient.StreamRoutes(ctx)
-		stream = transport.NewStreamV2(s, request)
+		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamRDS)
 	case resource.EndpointType:
 		s, err = m.edsClient.StreamEndpoints(ctx)
-		stream = transport.NewStreamV2(s, request)
+		stream = transport.NewStreamV2(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamEDS)
 	case resourcev3.ListenerType:
 		s, err = m.ldsClientV3.StreamListeners(ctx)
-		stream = transport.NewStreamV3(s, request)
+		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamLDS)
 	case resourcev3.ClusterType:
 		s, err = m.cdsClientV3.StreamClusters(ctx)
-		stream = transport.NewStreamV3(s, request)
+		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamCDS)
 	case resourcev3.RouteType:
 		s, err = m.rdsClientV3.StreamRoutes(ctx)
-		stream = transport.NewStreamV3(s, request)
+		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamRDS)
 	case resourcev3.EndpointType:
 		s, err = m.edsClientV3.StreamEndpoints(ctx)
-		stream = transport.NewStreamV3(s, request)
+		stream = transport.NewStreamV3(s, request, m.logger.Named("stream"))
 		scope = m.scope.SubScope(metrics.ScopeUpstreamEDS)
 	default:
 		defer cancel()
@@ -188,7 +188,7 @@ func (m *client) OpenStream(request transport.Request) (<-chan transport.Respons
 
 	response := make(chan transport.Response)
 
-	go send(ctx, m.logger, cancel, request, stream, signal, m.callOptions)
+	go send(ctx, m.logger, cancel, stream, signal, m.callOptions)
 	go recv(ctx, cancel, m.logger, response, stream, signal)
 
 	m.logger.With("request_type", request.GetTypeURL()).Info(ctx, "stream opened")
@@ -208,7 +208,6 @@ func send(
 	ctx context.Context,
 	logger log.Logger,
 	cancelFunc context.CancelFunc,
-	request transport.Request,
 	stream transport.Stream,
 	signal chan *version,
 	callOptions CallOptions) {
@@ -227,10 +226,6 @@ func send(
 				handleError(ctx, logger, "Error in SendMsg", cancelFunc, err)
 				return
 			}
-			logger.With(
-				"request_type", request.GetTypeURL(),
-				"request_version", request.GetVersionInfo(),
-			).Debug(ctx, "sent message")
 		case <-ctx.Done():
 			_ = stream.CloseSend()
 			return
@@ -253,11 +248,6 @@ func recv(
 			handleError(ctx, logger, "Error in RecvMsg", cancelFunc, err)
 			break
 		}
-		logger.With(
-			"response_version", resp.GetPayloadVersion(),
-			"response_type", resp.GetTypeURL(),
-			"resource_length", len(resp.GetResources()),
-		).Debug(context.Background(), "received message")
 		select {
 		case <-ctx.Done():
 			break

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -248,6 +248,7 @@ func recv(
 			handleError(ctx, logger, "Error in RecvMsg", cancelFunc, err)
 			break
 		}
+
 		select {
 		case <-ctx.Done():
 			break


### PR DESCRIPTION
When upstream control plane rotates, the grpc client has to make a new connection. Today we recognize an issue in the stream and dont retry. We should at least close the downstream sidecar streams, so that we get some semblance of retry from envoy sidecars. This could cause thundering herd, but this is a stopgap until the next PR fixes the retry.
Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>