### PR TITLE
Add stopgap for unaggregated keys

### DIFF
--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -37,6 +37,9 @@ const (
 	ErrorChannelFull             = "channel_full" // counter, # of response fanout failures due to blocked channels
 	ErrorUpstreamFailure         = "upstream"     // counter, # of errors as a result of a problem upstream
 	ErrorCacheMiss               = "cache_miss"   // counter, # of errors due to a fanout attempt with no cached response
+
+	// scope: .orchestrator.watch.errors.*
+	ErrorUnaggregatedKey = "unaggregated_key" // counter, # of errors due to an request that wasn't able to be mapped to an aggregated key
 )
 
 // .upstream
@@ -124,6 +127,13 @@ func OrchestratorWatchErrorsSubscope(parent tally.Scope, aggregatedKey string) t
 // ex: .orchestrator.cache_evict+key=$aggregated_key.
 func OrchestratorCacheEvictSubscope(parent tally.Scope, aggregatedKey string) tally.Scope {
 	return parent.SubScope(ScopeOrchestratorCacheEvict).Tagged(map[string]string{TagName: aggregatedKey})
+}
+
+// OrchestratorUnaggregatedWatchErrorsSubscope gets the orchestor watch subscope independent of
+// aggregated keys.
+// ex: .orchestrator.$aggregated_key.watch
+func OrchestratorUnaggregatedWatchErrorsSubscope(parent tally.Scope) tally.Scope {
+	return parent.SubScope(ScopeOrchestratorWatch).SubScope(ScopeOrchestratorWatchErrors)
 }
 
 // CacheFetchSubscope gets the cache fetch subscope and adds the aggregated key as a point tag.

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -39,7 +39,7 @@ const (
 	ErrorCacheMiss               = "cache_miss"   // counter, # of errors due to a fanout attempt with no cached response
 
 	// scope: .orchestrator.watch.errors.*
-	ErrorUnaggregatedKey = "unaggregated_key" // counter, # of errors due to an request that wasn't able to be mapped to an aggregated key
+	ErrorUnaggregatedKey = "unaggregated_key" // counter, # of request that would not map to an aggregated key
 )
 
 // .upstream

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -177,6 +177,35 @@ func TestGoldenPath(t *testing.T) {
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
 }
 
+func TestUnaggregatedKey(t *testing.T) {
+	upstreamResponseChannel := make(chan transport.Response)
+	mapper := mapper.NewMock(t)
+	mockScope := stats.NewMockScope("mock_orchestrator")
+	orchestrator := newMockOrchestrator(
+		t,
+		mockScope,
+		mapper,
+		mockSimpleUpstreamClient{
+			responseChan: upstreamResponseChannel,
+		},
+	)
+	assert.NotNil(t, orchestrator)
+	req := transport.NewRequestV2(
+		&gcp.Request{
+			TypeUrl: "type.googleapis.com/envoy.api.v2.UnsupportedType",
+		},
+	)
+	// assert this request will not map to an aggregated key.
+	_, err := mapper.GetKey(req)
+	assert.Error(t, err)
+
+	respChannel, _ := orchestrator.CreateWatch(req)
+	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
+		fmt.Sprintf("mock_orchestrator.watch.errors.unaggregated_key"), 1)
+	assert.NotNil(t, respChannel)
+	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+}
+
 func TestCachedResponse(t *testing.T) {
 	upstreamResponseChannel := make(chan transport.Response)
 	mapper := mapper.NewMock(t)

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -204,6 +204,8 @@ func TestUnaggregatedKey(t *testing.T) {
 		fmt.Sprintf("mock_orchestrator.watch.errors.unaggregated_key"), 1)
 	assert.NotNil(t, respChannel)
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+	_, more := <-respChannel.GetChannel().V2
+	assert.False(t, more)
 }
 
 func TestCachedResponse(t *testing.T) {


### PR DESCRIPTION
Log error and close the watch.

For longer term, there is an open issue to support unaggregated keys.

Signed-off-by: Jess Yuen <jyuen@lyft.com>