### PR TITLE
NACK logs + stat

### DIFF
--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -23,6 +23,7 @@ const (
 	// scope: .orchestrator.$aggregated_key.watch.*
 	ScopeOrchestratorWatch    = "watch"
 	OrchestratorWatchCreated  = "created"  // counter, # of watches created per aggregated key
+	OrchestratorNackWatchCreated  = "created_nack"  // counter, # of watches created per aggregated key in NACK requests
 	OrchestratorWatchCanceled = "canceled" // counter, # of watch cancels initiated per aggregated key
 	OrchestratorWatchFanouts  = "fanout"   // counter, # of responses pushed downstream
 

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -21,11 +21,12 @@ const (
 	ScopeOrchestrator = "orchestrator"
 
 	// scope: .orchestrator.$aggregated_key.watch.*
-	ScopeOrchestratorWatch    = "watch"
-	OrchestratorWatchCreated  = "created"  // counter, # of watches created per aggregated key
-	OrchestratorNackWatchCreated  = "created_nack"  // counter, # of watches created per aggregated key in NACK requests
-	OrchestratorWatchCanceled = "canceled" // counter, # of watch cancels initiated per aggregated key
-	OrchestratorWatchFanouts  = "fanout"   // counter, # of responses pushed downstream
+
+	ScopeOrchestratorWatch       = "watch"
+	OrchestratorWatchCreated     = "created"      // counter, # of watches created per aggregated key
+	OrchestratorNackWatchCreated = "created_nack" // counter, # of watches created per aggregated key in NACK requests
+	OrchestratorWatchCanceled    = "canceled"     // counter, # of watch cancels initiated per aggregated key
+	OrchestratorWatchFanouts     = "fanout"       // counter, # of responses pushed downstream
 
 	// scope: .orchestrator.$aggregated_key.cache_evict.*
 	ScopeOrchestratorCacheEvict            = "cache_evict"

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	bootstrapv1 "github.com/envoyproxy/xds-relay/pkg/api/bootstrap/v1"
@@ -169,9 +170,13 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 	// Log + stat to investigate NACK behavior
 	isNackRequest := req.GetError() != nil
 	if isNackRequest {
+		resourceString := ""
+		if req.GetResourceNames() != nil {
+			resourceString = strings.Join(req.GetResourceNames()[:], ",")
+		}
 		o.logger.With(
 			"request_version", req.GetVersionInfo(),
-			"resource_names", req.GetResourceNames(),
+			"resource_names", resourceString,
 			"nonce", req.GetResponseNonce(),
 			"request_type", req.GetTypeURL(),
 			"error", req.GetError(),

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -211,7 +211,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 						"aggregated_key", aggregatedKey,
 						"request_version", req.GetVersionInfo(),
 						"response_version", cached.Resp.GetPayloadVersion(),
-					).Debug(context.Background(),"NACK request receives cached response with different version")
+					).Debug(context.Background(), "NACK request receives cached response with different version")
 				}
 			}
 		}()
@@ -220,6 +220,11 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 	// Check if we have a upstream stream open for this aggregated key. If not,
 	// open a stream with the representative request.
 	if !o.upstreamResponseMap.exists(aggregatedKey) {
+		if isNackRequest {
+			o.logger.With(
+				"aggregated_key", aggregatedKey,
+			).Debug(context.Background(), "NACK request attempting to open new stream")
+		}
 		upstreamResponseChan, shutdown, err := o.upstreamClient.OpenStream(req)
 		if err != nil {
 			// TODO implement retry/back-off logic on error scenario.

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -417,7 +417,6 @@ func (o *orchestrator) shutdown(ctx context.Context) {
 	o.upstreamResponseMap.deleteAll()
 }
 
-
 func isNackRequest(req transport.Request) bool {
 	return req.GetError() != nil
 }

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -168,11 +168,11 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 	metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey).Counter(metrics.OrchestratorWatchCreated).Inc(1)
 
 	// Log + stat to investigate NACK behavior
-	resourceString := ""
-	if req.GetResourceNames() != nil {
-		resourceString = strings.Join(req.GetResourceNames()[:], ",")
-	}
 	if isNackRequest(req) {
+		resourceString := ""
+		if req.GetResourceNames() != nil {
+			resourceString = strings.Join(req.GetResourceNames()[:], ",")
+		}
 		o.logger.With(
 			"request_version", req.GetVersionInfo(),
 			"resource_names", resourceString,

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -498,7 +498,7 @@ func TestNACKRequest(t *testing.T) {
 	gotResponse := <-respChannel.GetChannel().V2
 	assertEqualResponse(t, gotResponse, mockResponse, req)
 
-	// If we pass this point, it's safe to assume the respChannel2 is empty,
+	// If we pass this point, it's safe to assume the respChannel is empty,
 	// otherwise the test would block and not complete.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -457,13 +457,12 @@ func TestNACKRequest(t *testing.T) {
 	assert.NotNil(t, orchestrator)
 
 	// Test scenario of client sending NACK request
-	errorDetail := status.Status{
-		Message: "test_error",
-	}
 	req := gcp.Request{
 		VersionInfo: "0",
 		TypeUrl:     "type.googleapis.com/envoy.api.v2.Listener",
-		ErrorDetail: &errorDetail,
+		ErrorDetail: &status.Status{
+			Message: "test_error",
+		},
 	}
 
 	aggregatedKey, err := mapper.GetKey(transport.NewRequestV2(&req))


### PR DESCRIPTION
Signed-off-by: Samra Belachew <sbelachew@lyft.com>

Added a couple of logs and a stat to NACK behavior in CreateWatch() to test out behavior of NACK requests. Stat will count number of NACK watches created per aggregated key. Logs provide detail on NACK request itself, whether it leads to a returned cached response, and if it opens up a new stream.