### PR TITLE
Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ Next step is to configure the `xds-relay` server. For that we need to provide 2 
   - an aggregation rules file
   - a bootstrap file
   
-You'll find one example of each file in this directory, `aggregation-rules.yaml` and `xds-relay-bootstrap.yaml` respectively.
+You'll find one example of each file in the `example/config-files` directory, `aggregation-rules.yaml` and `xds-relay-bootstrap.yaml` respectively.
 
 You're now ready to run `xds-relay` locally. Open another window in your terminal and run:
 
     ./bin/xds-relay -a example/config-files/aggregation-rules.yaml -c example/config-files/xds-relay-bootstrap.yaml -m serve
 
 #### Two envoy instances
-As a final step, it's time to connect 2 envoy clients to `xds-relay`. We will use [getenvoy](https://www.getenvoy.io/reference/getenvoy_run/) to set up your envoy clients (be sure to first fetch the desired binary version to run). You're going to find 2 files named `envoy-bootstrap-1.yaml` and `envoy-bootstrap-2.yaml` that we're going to use to connect the envoy instances to `xds-relay`. Open 2 terminal windows and run:
+As a final step, it's time to connect 2 envoy clients to `xds-relay`. If you do not have envoy installed, you can use [getenvoy](https://www.getenvoy.io/install/envoy/) to install the binary for your OS. You're going to find 2 files named `envoy-bootstrap-1.yaml` and `envoy-bootstrap-2.yaml` that we're going to use to connect the envoy instances to `xds-relay`. Open 2 terminal windows and run:
 
-    getenvoy run <envoy binary reference/filepath> -- -c example/config-files/envoy-bootstrap-1.yaml # on the first window
-    getenvoy run <envoy binary reference/filepath> -- -c example/config-files/envoy-bootstrap-2.yaml # on the second window
+    envoy -c example/config-files/envoy-bootstrap-1.yaml # on the first window
+    envoy -c example/config-files/envoy-bootstrap-2.yaml # on the second window
 
 And voilà! You should be seeing logs flowing in both the terminal window where you're running `xds-relay` and on each of the envoy ones. 
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ And voilà! You should be seeing logs flowing in both the terminal window where 
 
 We expose the contents of the cache in `xds-relay` via an endpoint, so we can use that to verify what are the contents of the cache for the keys being requested by the two envoy clients:
 
-    curl -s 0:6070/cache/cluster1_cds | jq '(.Resp.Resources.Clusters | map({"name": .name})) as $resp_clusters | (.Requests | map({"version_info": .version_info, "node.id": .node.id, "node.cluster": .node.cluster})) as $reqs | {"response": {"version": .Resp.VersionInfo, "clusters": $resp_clusters}, "requests": $reqs}'
+    curl -s 0:6070/cache/cluster1_cds | jq '(.Cache[0].Resp.Resources.Clusters | map({"name": .name})) as $resp_clusters | (.Cache[0].Requests | map({"version_info": .version_info, "node.id": .node.id, "node.cluster": .node.cluster})) as $reqs | {"response": {"version": .Cache[0].Resp.VersionInfo, "clusters": $resp_clusters}, "requests": $reqs}'
 
 Sample result:
 
 ``` shellsession
-❯ curl -s 0:6070/cache/cluster1_cds | jq '(.Resp.Resources.Clusters | map({"name": .name})) as $resp_clusters | (.Requests | map({"version_info": .version_info, "node.id": .node.id, "node.cluster": .node.cluster})) as $reqs | {"response": {"version": .Resp.VersionInfo, "clusters": $resp_clusters}, "requests": $reqs}'
+❯ curl -s 0:6070/cache/cluster1_cds | jq '(.Cache[0].Resp.Resources.Clusters | map({"name": .name})) as $resp_clusters | (.Cache[0].Requests | map({"version_info": .version_info, "node.id": .node.id, "node.cluster": .node.cluster})) as $reqs | {"response": {"version": .Cache[0].Resp.VersionInfo, "clusters": $resp_clusters}, "requests": $reqs}'
 {
   "response": {
     "version": "v66936",

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Sample result:
     "requests": [
       {
         "version_info": "v66936",
-        "node.id": "xds-relay",
-        "node.cluster": "cluster1"
+        "node.id": "envoy-client-1",
+        "node.cluster": "staging"
       },
       {
         "version_info": "v66936",
-        "node.id": "xds-relay-2",
-        "node.cluster": "cluster1"
+        "node.id": "envoy-client-2",
+        "node.cluster": "staging"
       }
     ]
   }

--- a/example/config-files/envoy-bootstrap-1.yaml
+++ b/example/config-files/envoy-bootstrap-1.yaml
@@ -1,6 +1,6 @@
 node:
-  id: xds-relay
-  cluster: cluster1
+  id: envoy-client-1
+  cluster: staging
 admin:
   access_log_path: /dev/null
   address:

--- a/example/config-files/envoy-bootstrap-2.yaml
+++ b/example/config-files/envoy-bootstrap-2.yaml
@@ -1,6 +1,6 @@
 node:
-  id: xds-relay-2
-  cluster: cluster1
+  id: envoy-client-2
+  cluster: staging
 admin:
   access_log_path: /dev/null
   address:

--- a/example/main.go
+++ b/example/main.go
@@ -43,7 +43,7 @@ func generateTestSnapshotNewVersion(snapshotCache cache.SnapshotCache) {
 		if err := snapshot.Consistent(); err != nil {
 			fmt.Printf("snapshot inconsistency: %+v", snapshot)
 		}
-		err := snapshotCache.SetSnapshot("xds-relay", snapshot)
+		err := snapshotCache.SetSnapshot("envoy-client-1", snapshot)
 		if err != nil {
 			fmt.Printf("set snapshot error %q for %+v", err, snapshot)
 		}


### PR DESCRIPTION
* to use getenvoy to install the binary instead of running it via `getenvoy run`. On Mac, there is process exiting issues following the standard:1.11.1 instructions.
* clarify dir where example configurations are located.
* clearer naming for envoy client node IDs and clusters
* update jq queries to reflect .Cache[0] parent (currently broken)

Signed-off-by: Jess Yuen <jyuen@lyft.com>