### PR TITLE
Retry upstream stream failures

### DIFF
--- a/integration/upstream_client_test.go
+++ b/integration/upstream_client_test.go
@@ -1,3 +1,5 @@
+// +build integration
+
 package integration
 
 import (

--- a/integration/upstream_client_test.go
+++ b/integration/upstream_client_test.go
@@ -1,4 +1,5 @@
 // +build integration
+
 package integration
 
 import (

--- a/integration/upstream_client_test.go
+++ b/integration/upstream_client_test.go
@@ -1,5 +1,3 @@
-// +build integration
-
 package integration
 
 import (
@@ -168,13 +166,13 @@ func TestClientContextCancellationShouldCloseAllResponseChannels(t *testing.T) {
 		log.MockLogger,
 		stats.NewMockScope("mock"),
 	)
-	respCh1, _, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
+	respCh1, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
 		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
 	}))
-	respCh2, _, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
+	respCh2, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
 		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
@@ -233,17 +231,12 @@ func setup(
 		return nil, nil, err
 	}
 
-	respCh, shutdown, err := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
+	respCh, shutdown := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
 		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
 	}))
-
-	if err != nil {
-		logger.Error(ctx, "Open stream failed %s", err.Error())
-		return nil, nil, err
-	}
 
 	select {
 	case <-cb.Signal:

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/envoyproxy/xds-relay/internal/app/upstream"
 
 	"github.com/envoyproxy/xds-relay/internal/pkg/log"
+	"github.com/envoyproxy/xds-relay/internal/pkg/stats"
 
 	"github.com/envoyproxy/xds-relay/internal/app/mapper"
 	"github.com/envoyproxy/xds-relay/internal/app/orchestrator"
@@ -112,6 +113,7 @@ func TestAdminServer_CacheDumpHandler(t *testing.T) {
 		nil,
 		nil,
 		func(m interface{}) error { return nil },
+		stats.NewMockScope("mock"),
 	)
 	orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 	assert.NotNil(t, orchestrator)
@@ -174,6 +176,7 @@ func TestAdminServer_CacheDumpHandler_NotFound(t *testing.T) {
 		nil,
 		upstreamResponseChannel,
 		func(m interface{}) error { return nil },
+		stats.NewMockScope("mock"),
 	)
 	orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 	assert.NotNil(t, orchestrator)
@@ -205,6 +208,7 @@ func TestAdminServer_CacheDumpHandler_EntireCache(t *testing.T) {
 			nil,
 			upstreamResponseChannelCDS,
 			func(m interface{}) error { return nil },
+			stats.NewMockScope("mock"),
 		)
 		orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 		assert.NotNil(t, orchestrator)
@@ -403,6 +407,7 @@ func TestAdminServer_CacheDumpHandler_WildcardSuffix(t *testing.T) {
 			nil,
 			upstreamResponseChannelCDS,
 			func(m interface{}) error { return nil },
+			stats.NewMockScope("scope"),
 		)
 		orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 		assert.NotNil(t, orchestrator)
@@ -605,6 +610,7 @@ func TestAdminServer_CacheDumpHandler_WildcardSuffix_NotFound(t *testing.T) {
 			nil,
 			upstreamResponseChannelCDS,
 			func(m interface{}) error { return nil },
+			stats.NewMockScope("mock"),
 		)
 		orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 		assert.NotNil(t, orchestrator)

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -309,6 +309,7 @@ func TestAdminServer_CacheDumpHandler_EntireCacheV3(t *testing.T) {
 			nil,
 			upstreamResponseChannelCDS,
 			func(m interface{}) error { return nil },
+			stats.NewMockScope("mock"),
 		)
 		orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 		assert.NotNil(t, orchestrator)
@@ -508,6 +509,7 @@ func TestAdminServer_CacheDumpHandler_WildcardSuffixV3(t *testing.T) {
 			nil,
 			upstreamResponseChannelCDS,
 			func(m interface{}) error { return nil },
+			stats.NewMockScope("mock"),
 		)
 		orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 		assert.NotNil(t, orchestrator)

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -58,6 +58,8 @@ const (
 
 	UpstreamStreamOpened = "stream_opened" // counter, # of times a gRPC stream was opened to the origin server.
 
+	UpstreamStreamCreationFailure = "stream_failure" // counter, # of times a gRPC stream creation failed.
+
 	UpstreamConnected = "connected"
 )
 

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -194,28 +194,19 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 	// Check if we have a upstream stream open for this aggregated key. If not,
 	// open a stream with the representative request.
 	if !o.upstreamResponseMap.exists(aggregatedKey) {
-		upstreamResponseChan, shutdown, err := o.upstreamClient.OpenStream(req)
-		if err != nil {
-			// TODO implement retry/back-off logic on error scenario.
-			// https://github.com/envoyproxy/xds-relay/issues/68
-			o.logger.With(
-				"error", err,
-				"aggregated_key", aggregatedKey,
-			).Error(ctx, "Failed to open stream to origin server")
+		upstreamResponseChan, shutdown := o.upstreamClient.OpenStream(req)
+		respChannel, upstreamOpenedPreviously := o.upstreamResponseMap.add(aggregatedKey, upstreamResponseChan)
+		if upstreamOpenedPreviously {
+			// A stream was opened previously due to a race between
+			// concurrent downstreams for the same aggregated key, between
+			// exists and add operations. In this event, simply close the
+			// slower stream and return the existing one.
+			shutdown()
 		} else {
-			respChannel, upstreamOpenedPreviously := o.upstreamResponseMap.add(aggregatedKey, upstreamResponseChan)
-			if upstreamOpenedPreviously {
-				// A stream was opened previously due to a race between
-				// concurrent downstreams for the same aggregated key, between
-				// exists and add operations. In this event, simply close the
-				// slower stream and return the existing one.
-				shutdown()
-			} else {
-				// Spin up a go routine to watch for upstream responses.
-				// One routine is opened per aggregate key.
-				o.logger.With("aggregated_key", aggregatedKey).Debug(ctx, "watching upstream")
-				go o.watchUpstream(ctx, aggregatedKey, respChannel.response, respChannel.done, shutdown)
-			}
+			// Spin up a go routine to watch for upstream responses.
+			// One routine is opened per aggregate key.
+			o.logger.With("aggregated_key", aggregatedKey).Debug(ctx, "watching upstream")
+			go o.watchUpstream(ctx, aggregatedKey, respChannel.response, respChannel.done, shutdown)
 		}
 	}
 

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -29,8 +29,8 @@ type mockSimpleUpstreamClient struct {
 	responseChan <-chan transport.Response
 }
 
-func (m mockSimpleUpstreamClient) OpenStream(req transport.Request) (<-chan transport.Response, func(), error) {
-	return m.responseChan, func() {}, nil
+func (m mockSimpleUpstreamClient) OpenStream(req transport.Request) (<-chan transport.Response, func()) {
+	return m.responseChan, func() {}
 }
 
 type mockMultiStreamUpstreamClient struct {
@@ -43,18 +43,18 @@ type mockMultiStreamUpstreamClient struct {
 
 func (m mockMultiStreamUpstreamClient) OpenStream(
 	req transport.Request,
-) (<-chan transport.Response, func(), error) {
+) (<-chan transport.Response, func()) {
 	aggregatedKey, err := m.mapper.GetKey(req)
 	assert.NoError(m.t, err)
 
 	if aggregatedKey == "lds" {
-		return m.ldsResponseChan, func() {}, nil
+		return m.ldsResponseChan, func() {}
 	} else if aggregatedKey == "cds" {
-		return m.cdsResponseChan, func() {}, nil
+		return m.cdsResponseChan, func() {}
 	}
 
 	m.t.Errorf("Unsupported aggregated key, %s", aggregatedKey)
-	return nil, func() {}, nil
+	return nil, func() {}
 }
 
 func newMockOrchestrator(t *testing.T, mockScope tally.Scope, mapper mapper.Mapper,
@@ -93,6 +93,7 @@ func TestNew(t *testing.T) {
 		nil,
 		nil,
 		func(m interface{}) error { return nil },
+		stats.NewMockScope("mock"),
 	)
 
 	config := aggregationv1.KeyerConfiguration{

--- a/internal/app/upstream/client_mock.go
+++ b/internal/app/upstream/client_mock.go
@@ -31,6 +31,7 @@ func NewMockClient(
 		callOptions: callOptions,
 		logger:      log.MockLogger,
 		scope:       scope,
+		shutdown:    make(<-chan struct{}),
 	}
 }
 
@@ -51,6 +52,7 @@ func NewMockClientV3(
 		callOptions: callOptions,
 		logger:      log.MockLogger,
 		scope:       scope,
+		shutdown:    make(<-chan struct{}),
 	}
 }
 

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -358,13 +358,11 @@ func TestOpenStreamShouldRetryWhenSendMsgBlocks(t *testing.T) {
 	responseChan := make(chan *v2.DiscoveryResponse)
 	blockedCtx, cancel := context.WithCancel(context.Background())
 	first := true
-	response1 := &v2.DiscoveryResponse{VersionInfo: "1"}
 	response2 := &v2.DiscoveryResponse{VersionInfo: "2"}
 	client := createMockClientWithResponse(time.Nanosecond, responseChan, func(m interface{}) error {
 		if first {
 			first = !first
 			<-blockedCtx.Done()
-			responseChan <- response1
 			return nil
 		}
 		responseChan <- response2
@@ -380,16 +378,10 @@ func TestOpenStreamShouldRetryWhenSendMsgBlocks(t *testing.T) {
 	assert.Equal(t, resp.Get().V2.VersionInfo, response2.VersionInfo)
 
 	cancel()
-	select {
-	case v := <-respCh:
-		assert.Fail(t, "Channel should not contain any response %s", v.Get().V2.VersionInfo)
-	default:
-	}
-
 	done()
 }
 
-func TestOpenStreamShouldSendErrorWhenSendMsgBlocksV3(t *testing.T) {
+func TestOpenStreamShouldRetryWhenSendMsgBlocksV3(t *testing.T) {
 	responseChan := make(chan *discoveryv3.DiscoveryResponse)
 	blockedCtx, cancel := context.WithCancel(context.Background())
 	first := true
@@ -415,12 +407,6 @@ func TestOpenStreamShouldSendErrorWhenSendMsgBlocksV3(t *testing.T) {
 	assert.Equal(t, resp.Get().V3.VersionInfo, response2.VersionInfo)
 
 	cancel()
-	select {
-	case v := <-respCh:
-		assert.Fail(t, "Channel should not contain any response %s", v.Get().V3.VersionInfo)
-	default:
-	}
-
 	done()
 }
 

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -64,7 +64,7 @@ func TestOpenStreamShouldRetryOnStreamCreationFailure(t *testing.T) {
 			}
 			for {
 				if v, ok := scope.Snapshot().Counters()[stats[1]]; ok {
-					assert.Equal(t, int64(1), v.Value())
+					assert.NotEqual(t, int64(0), v.Value())
 					break
 				}
 			}
@@ -98,7 +98,7 @@ func TestOpenStreamShouldNotRetryOnStreamCreationFailureV3(t *testing.T) {
 			}
 			for {
 				if v, ok := scope.Snapshot().Counters()[stats[1]]; ok {
-					assert.Equal(t, int64(1), v.Value())
+					assert.NotEqual(t, int64(0), v.Value())
 					break
 				}
 			}

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -38,7 +38,7 @@ func TestOpenStreamShouldReturnErrorForInvalidTypeUrlV3(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestOpenStreamShouldNotReturnErrorOnStreamCreationFailure(t *testing.T) {
+func TestOpenStreamShouldRetryOnStreamCreationFailure(t *testing.T) {
 	scope := stats.NewMockScope("mock")
 	client := createMockClientWithError(scope)
 
@@ -72,7 +72,7 @@ func TestOpenStreamShouldNotReturnErrorOnStreamCreationFailure(t *testing.T) {
 	}
 }
 
-func TestOpenStreamShouldNotReturnErrorOnStreamCreationFailureV3(t *testing.T) {
+func TestOpenStreamShouldNotRetryOnStreamCreationFailureV3(t *testing.T) {
 	scope := stats.NewMockScope("mock")
 	client := createMockClientWithErrorV3(scope)
 
@@ -381,8 +381,8 @@ func TestOpenStreamShouldRetryWhenSendMsgBlocks(t *testing.T) {
 
 	cancel()
 	select {
-	case <-respCh:
-		assert.Fail(t, "Channel should not contain any response")
+	case v := <-respCh:
+		assert.Fail(t, "Channel should not contain any response %s", v.Get().V2.VersionInfo)
 	default:
 	}
 

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -416,8 +416,8 @@ func TestOpenStreamShouldSendErrorWhenSendMsgBlocksV3(t *testing.T) {
 
 	cancel()
 	select {
-	case <-respCh:
-		assert.Fail(t, "Channel should not contain any response")
+	case v := <-respCh:
+		assert.Fail(t, "Channel should not contain any response %s", v.Get().V3.VersionInfo)
 	default:
 	}
 

--- a/internal/app/upstream/stream_mockv2.go
+++ b/internal/app/upstream/stream_mockv2.go
@@ -11,7 +11,7 @@ import (
 )
 
 type mockClient struct {
-	errorOnStreamCreate error
+	errorOnStreamCreate []error
 	receiveChan         chan *v2.DiscoveryResponse
 	sendCb              func(m interface{}) error
 }
@@ -70,8 +70,10 @@ func (stream *mockGrpcStream) Context() context.Context {
 func (c *mockClient) StreamListeners(
 	ctx context.Context,
 	opts ...grpc.CallOption) (v2.ListenerDiscoveryService_StreamListenersClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStream{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }
@@ -79,8 +81,10 @@ func (c *mockClient) StreamListeners(
 func (c *mockClient) StreamClusters(
 	ctx context.Context,
 	opts ...grpc.CallOption) (v2.ClusterDiscoveryService_StreamClustersClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStream{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }
@@ -88,8 +92,10 @@ func (c *mockClient) StreamClusters(
 func (c *mockClient) StreamRoutes(
 	ctx context.Context,
 	opts ...grpc.CallOption) (v2.RouteDiscoveryService_StreamRoutesClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStream{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }
@@ -97,8 +103,10 @@ func (c *mockClient) StreamRoutes(
 func (c *mockClient) StreamEndpoints(
 	ctx context.Context,
 	opts ...grpc.CallOption) (v2.EndpointDiscoveryService_StreamEndpointsClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStream{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }

--- a/internal/app/upstream/stream_mockv3.go
+++ b/internal/app/upstream/stream_mockv3.go
@@ -15,7 +15,7 @@ import (
 )
 
 type mockClientV3 struct {
-	errorOnStreamCreate error
+	errorOnStreamCreate []error
 	receiveChan         chan *v2.DiscoveryResponse
 	sendCb              func(m interface{}) error
 }
@@ -74,8 +74,10 @@ func (stream *mockGrpcStreamV3) Context() context.Context {
 func (c *mockClientV3) StreamListeners(
 	ctx context.Context,
 	opts ...grpc.CallOption) (listenerservice.ListenerDiscoveryService_StreamListenersClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStreamV3{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }
@@ -83,8 +85,10 @@ func (c *mockClientV3) StreamListeners(
 func (c *mockClientV3) StreamClusters(
 	ctx context.Context,
 	opts ...grpc.CallOption) (clusterservice.ClusterDiscoveryService_StreamClustersClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStreamV3{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }
@@ -92,8 +96,10 @@ func (c *mockClientV3) StreamClusters(
 func (c *mockClientV3) StreamRoutes(
 	ctx context.Context,
 	opts ...grpc.CallOption) (routeservice.RouteDiscoveryService_StreamRoutesClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStreamV3{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }
@@ -101,8 +107,10 @@ func (c *mockClientV3) StreamRoutes(
 func (c *mockClientV3) StreamEndpoints(
 	ctx context.Context,
 	opts ...grpc.CallOption) (endpointservice.EndpointDiscoveryService_StreamEndpointsClient, error) {
-	if c.errorOnStreamCreate != nil {
-		return nil, c.errorOnStreamCreate
+	if c.errorOnStreamCreate != nil && len(c.errorOnStreamCreate) != 0 {
+		e := c.errorOnStreamCreate[0]
+		c.errorOnStreamCreate = c.errorOnStreamCreate[1:]
+		return nil, e
 	}
 	return &mockGrpcStreamV3{ctx: ctx, receiveChan: c.receiveChan, sendCb: c.sendCb}, nil
 }


### PR DESCRIPTION
This PR proposes the following change in behavior:
- Any stream errors in send and recv are retried by the client.
- Any stream creation errors are retried by client
- A malformed/unsupported typeurl causes the response channel to be closed and orchestrator will close the downstream watches. We earlier did the work for the orchestrator to close the watches when response channel is closed. This is not expected to cause any thundering herd issue.
- The retry eventually succeeds or keeps incrementing a stat. We can add alarms around the stat.
- TTL expiry can still cancel the top level context and the retry stops. The cancel flow has been demonstrated in the integration tests.

Grpc concepts on which the impl relies:
1. grpc takes care of connection management. Once the connection is established, it needs no work from the client to reconnect on backend closures, creating new cx on goaway frames, and any other cx related scenario. The connection is picked back up when the backend starts responding.
2. Streams are ephemeral and even when cx is closed using ctx cancel, stream creation fails with a grpc status code 14, similar to when backend is unavailable. We make sure to cancel stream creation when ctx is cancelled.
3. The default grpc cx connect params are https://github.com/grpc/grpc-go/blob/v1.32.0/backoff/backoff.go#L47-L51. These default params work for now and we can revisit these later when we need any tuning.
4. Retrying new streams on failure is not expensive since stream creation is based on cx characteristics, however we do intend to add backoff functionality. This is intended for a separate PR.
5. Once a stream has an error, it becomes aborted and cannot be reused. In our case both recv and send have to use the same stream and need coordination to bail out.