### PR TITLE
fix oomkilled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,5 @@ require (
 	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a
 	google.golang.org/grpc v1.27.1
 	google.golang.org/protobuf v1.23.0
+	go.uber.org/goleak v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -240,6 +240,8 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/goleak v1.1.0 h1:MJDxhkyAAWXEJf/y4NSOPYD/bBx7JAzIjUbv12/4FFs=
+go.uber.org/goleak v1.1.0/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0 h1:sFPn2GLc3poCkfrpIXGhBD2X0CMIo4Q/zSULXrj/+uc=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
@@ -345,6 +347,7 @@ golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191112195655-aa38f8e97acc/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200527150044-688b3c5d9fa5 h1:3KBjmg2slvQXATWW9cQJ6tsRc8hj1gsnwWyi1IzYk3o=

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -221,7 +221,6 @@ func (m *client) handleStreamsWithRetry(
 			}
 
 			signal := make(chan *version, 1)
-			defer close(signal)
 			m.logger.With("request_type", request.GetTypeURL()).Info(ctx, "stream opened")
 			scope.Counter(metrics.UpstreamStreamOpened).Inc(1)
 			// The xds protocol https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#ack
@@ -235,6 +234,7 @@ func (m *client) handleStreamsWithRetry(
 			go recv(childCtx, wg.Done, cancel, m.logger, respCh, stream, signal)
 
 			wg.Wait()
+			close(signal)
 		}
 	}
 }

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -234,7 +234,6 @@ func (m *client) handleStreamsWithRetry(
 			go recv(childCtx, wg.Done, cancel, m.logger, respCh, stream, signal)
 
 			wg.Wait()
-			close(signal)
 		}
 	}
 }

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -234,6 +234,7 @@ func (m *client) handleStreamsWithRetry(
 			go recv(childCtx, wg.Done, cancel, m.logger, respCh, stream, signal)
 
 			wg.Wait()
+			close(signal)
 		}
 	}
 }
@@ -299,7 +300,6 @@ func recv(
 			signal <- &version{version: resp.GetPayloadVersion(), nonce: resp.GetNonce()}
 		}
 	}
-	close(signal)
 }
 
 func handleError(ctx context.Context, logger log.Logger, errMsg string, cancelFunc context.CancelFunc, err error) {

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -289,12 +289,12 @@ func recv(
 		resp, err := stream.RecvMsg()
 		if err != nil {
 			handleError(ctx, logger, "Error in RecvMsg", cancelFunc, err)
-			break
+			return
 		}
 
 		select {
 		case <-ctx.Done():
-			break
+			return
 		default:
 			response <- resp
 			signal <- &version{version: resp.GetPayloadVersion(), nonce: resp.GetNonce()}

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -18,11 +18,13 @@ import (
 	"github.com/envoyproxy/xds-relay/internal/pkg/stats"
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
+	"go.uber.org/goleak"
 )
 
 type CallOptions = upstream.CallOptions
 
 func TestOpenStreamShouldReturnErrorForInvalidTypeUrl(t *testing.T) {
+	defer goleak.VerifyNone(t)
 	client := createMockClient()
 
 	respCh, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{}))

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -242,6 +242,7 @@ func TestOpenStreamShouldRetryIfSendFails(t *testing.T) {
 	errResp := true
 	response := &v2.DiscoveryResponse{}
 	exit := make(chan struct{})
+	defer close(exit)
 	client := createMockClientWithResponse(ctx, time.Second, responseChan, func(m interface{}) error {
 		if errResp {
 			errResp = false
@@ -265,7 +266,6 @@ func TestOpenStreamShouldRetryIfSendFails(t *testing.T) {
 	defer done()
 	_, more := <-resp
 	assert.True(t, more)
-	close(exit)
 }
 
 func TestOpenStreamShouldRetryIfSendFailsV3(t *testing.T) {
@@ -277,6 +277,7 @@ func TestOpenStreamShouldRetryIfSendFailsV3(t *testing.T) {
 	errResp := true
 	response := &discoveryv3.DiscoveryResponse{}
 	exit := make(chan struct{})
+	defer close(exit)
 	client := createMockClientWithResponseV3(ctx, time.Second, responseChan, func(m interface{}) error {
 		if errResp {
 			errResp = false
@@ -300,7 +301,6 @@ func TestOpenStreamShouldRetryIfSendFailsV3(t *testing.T) {
 	defer done()
 	_, more := <-resp
 	assert.True(t, more)
-	close(exit)
 }
 
 func TestOpenStreamShouldSendTheResponseOnTheChannel(t *testing.T) {

--- a/internal/app/upstream/stream_mockv2.go
+++ b/internal/app/upstream/stream_mockv2.go
@@ -23,7 +23,12 @@ type mockGrpcStream struct {
 }
 
 func (stream *mockGrpcStream) SendMsg(m interface{}) error {
-	return stream.sendCb(m)
+	select {
+	case <-stream.ctx.Done():
+		return nil
+	default:
+		return stream.sendCb(m)
+	}
 }
 
 func (stream *mockGrpcStream) RecvMsg(m interface{}) error {

--- a/internal/app/upstream/stream_mockv3.go
+++ b/internal/app/upstream/stream_mockv3.go
@@ -27,7 +27,12 @@ type mockGrpcStreamV3 struct {
 }
 
 func (stream *mockGrpcStreamV3) SendMsg(m interface{}) error {
-	return stream.sendCb(m)
+	select {
+	case <-stream.ctx.Done():
+		return nil
+	default:
+		return stream.sendCb(m)
+	}
 }
 
 func (stream *mockGrpcStreamV3) RecvMsg(m interface{}) error {


### PR DESCRIPTION
While deploying to staging we realized that in case of stream retries, the xdsrelay pods were getting oomkilled.
The OOM was happening due to goroutine leak in the upstream client.

In order to fix it, we used `go.uber.org/goleak` ([doc](https://github.com/uber-go/goleak)) in the test cases, and fixed the leaks using test cases. The resulting code does not OOM kill anymore. 

Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>