### PR TITLE
Fix flakey tests

### DIFF
--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -620,13 +620,8 @@ func createMockClientWithResponseV3(
 }
 
 func blockUntilClean(resp <-chan transport.Response, tearDown func()) {
-	for {
-		select {
-		case _, ok := <-resp:
-			if !ok {
-				tearDown()
-				return
-			}
-		}
+	for range resp {
 	}
+
+	tearDown()
 }

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -366,7 +366,6 @@ func TestOpenStreamShouldSendTheResponseOnTheChannelV3(t *testing.T) {
 func TestOpenStreamShouldSendTheNextRequestWithUpdatedVersionAndNonce(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	responseChan := make(chan *v2.DiscoveryResponse)
 	lastAppliedVersion := ""
 	index := 0


### PR DESCRIPTION
In the upstream client tests, the `defer` way of closing goroutines was turning out to be flakey. By the time the go-leak ran the goroutines were not always done.
Instead we have to explicitly wait for each test cleanup before the go-leak ran. In go tests there is no way to add a per test teardown hook.

Verfied each test with `-count=100`

Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>