### PR TITLE
Handle NACK

### DIFF
--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -191,7 +191,9 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 		o.logger.With("error", err).With("aggregated_key", aggregatedKey).Warn(ctx, "failed to fetch aggregated key")
 	}
 
-	if cached != nil && cached.Resp != nil && cached.Resp.GetPayloadVersion() != req.GetVersionInfo() {
+	if cached != nil && cached.Resp != nil &&
+		cached.Resp.GetPayloadVersion() != req.GetVersionInfo() &&
+		req.GetError() == nil {
 		// If we have a cached response and the version is different,
 		// immediately push the result to the response channel.
 		go func() {

--- a/internal/app/transport/streamv2.go
+++ b/internal/app/transport/streamv2.go
@@ -29,6 +29,7 @@ func (s *streamv2) SendMsg(version string, nonce string) error {
 	msg := s.initialRequest.GetRaw().V2
 	msg.VersionInfo = version
 	msg.ResponseNonce = nonce
+	msg.ErrorDetail = nil
 	s.logger.With(
 		"request_type", msg.GetTypeUrl(),
 		"request_version", msg.GetVersionInfo(),

--- a/internal/app/transport/streamv3.go
+++ b/internal/app/transport/streamv3.go
@@ -28,6 +28,7 @@ func NewStreamV3(clientStream grpc.ClientStream, req Request, l log.Logger) Stre
 func (s *streamv3) SendMsg(version string, nonce string) error {
 	msg := s.initialRequest.GetRaw().V3
 	msg.VersionInfo = version
+	msg.ErrorDetail = nil
 	msg.ResponseNonce = nonce
 	s.logger.With(
 		"request_type", msg.GetTypeUrl(),


### PR DESCRIPTION
The PR handles 2 scenarios:
1. A nack request can cause endless to-fro between a sidecar and xdsrelay. In case of NACK the version never updates. so the sidecar's version will never match the cache's version, causing immediate response from cache. The immediate response should only be sent when the request is not a nack. When the request is a nack, the watch should hold until a further update is received from upstream.
2. xdsrelay upstream client always caches the first request and uses it for the further upstream requests until cache is evicted. In case the first request was a nack(can happen when xdsrelay server instance just started up), we still need to update the cache, but should not send the ErrorDetails. Most upstream control planes hold the watch on nack request(verified with istio and contour). In that case a misbehaving sidecar sending nack request can starve other other sidecars from receiving an update. 