### PR TITLE
Add more client stats/logs per aggregated key

### DIFF
--- a/integration/upstream_client_test.go
+++ b/integration/upstream_client_test.go
@@ -176,13 +176,13 @@ func TestClientContextCancellationShouldCloseAllResponseChannels(t *testing.T) {
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
-	}))
+	}), "aggregated_key")
 	respCh2, _ := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
 		TypeUrl: resource.ClusterType,
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
-	}))
+	}), "aggregated_key")
 
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -246,7 +246,7 @@ func setup(
 		Node: &corev2.Node{
 			Id: nodeID,
 		},
-	}))
+	}), "aggregated_key")
 
 	select {
 	case <-cb.Signal:

--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -60,6 +60,8 @@ const (
 
 	UpstreamStreamOpened = "stream_opened" // counter, # of times a gRPC stream was opened to the origin server.
 
+	UpstreamStreamRetry = "stream_retry" // counter, # of times a gRPC stream was opened to the origin server.
+
 	UpstreamStreamCreationFailure = "stream_failure" // counter, # of times a gRPC stream creation failed.
 
 	UpstreamConnected = "connected"

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -214,7 +214,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 	// Check if we have a upstream stream open for this aggregated key. If not,
 	// open a stream with the representative request.
 	if !o.upstreamResponseMap.exists(aggregatedKey) {
-		upstreamResponseChan, shutdown := o.upstreamClient.OpenStream(req)
+		upstreamResponseChan, shutdown := o.upstreamClient.OpenStream(req, aggregatedKey)
 		respChannel, upstreamOpenedPreviously := o.upstreamResponseMap.add(aggregatedKey, upstreamResponseChan)
 		if upstreamOpenedPreviously {
 			// A stream was opened previously due to a race between

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -30,7 +30,7 @@ type mockSimpleUpstreamClient struct {
 	responseChan <-chan transport.Response
 }
 
-func (m mockSimpleUpstreamClient) OpenStream(req transport.Request) (<-chan transport.Response, func()) {
+func (m mockSimpleUpstreamClient) OpenStream(req transport.Request, key string) (<-chan transport.Response, func()) {
 	return m.responseChan, func() {}
 }
 
@@ -43,7 +43,7 @@ type mockMultiStreamUpstreamClient struct {
 }
 
 func (m mockMultiStreamUpstreamClient) OpenStream(
-	req transport.Request,
+	req transport.Request, key string,
 ) (<-chan transport.Response, func()) {
 	aggregatedKey, err := m.mapper.GetKey(req)
 	assert.NoError(m.t, err)
@@ -203,7 +203,7 @@ func TestUnaggregatedKey(t *testing.T) {
 
 	respChannel, _ := orchestrator.CreateWatch(req)
 	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
-		fmt.Sprintf("mock_orchestrator.watch.errors.unaggregated_key"), 1)
+		"mock_orchestrator.watch.errors.unaggregated_key", 1)
 	assert.NotNil(t, respChannel)
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
 	_, more := <-respChannel.GetChannel().V2

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -165,7 +165,7 @@ func (m *client) handleStreamsWithRetry(
 			if !ok {
 				cancel()
 				close(respCh)
-				m.logger.With("aggregated_key", aggregatedKey).Info(ctx, "server shutdown")
+				m.logger.With("aggregated_key", aggregatedKey).Info(ctx, "stream shutdown")
 				return
 			}
 		case <-ctx.Done():

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -218,7 +218,7 @@ func (m *client) handleStreamsWithRetry(
 			}
 			scope = scope.Tagged(map[string]string{metrics.TagName: aggregatedKey})
 			if err != nil {
-				m.logger.With("request_type", request.GetTypeURL()).Warn(ctx, "stream failed")
+				m.logger.With("request_type", request.GetTypeURL(), "aggregated_key", aggregatedKey).Warn(ctx, "stream failed")
 				scope.Counter(metrics.UpstreamStreamCreationFailure).Inc(1)
 				cancel()
 				continue

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -33,7 +33,7 @@ func TestOpenStreamShouldReturnErrorForInvalidTypeUrl(t *testing.T) {
 	defer cancel()
 	client := createMockClient(ctx)
 
-	respCh, done := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{}))
+	respCh, done := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{}), "aggregated_key")
 	defer done()
 	_, ok := <-respCh
 	assert.False(t, ok)
@@ -44,7 +44,7 @@ func TestOpenStreamShouldReturnErrorForInvalidTypeUrlV3(t *testing.T) {
 	defer cancel()
 	client := createMockClientV3(ctx)
 
-	respCh, done := client.OpenStream(transport.NewRequestV3(&discoveryv3.DiscoveryRequest{}))
+	respCh, done := client.OpenStream(transport.NewRequestV3(&discoveryv3.DiscoveryRequest{}), "aggregated_key")
 	defer done()
 	_, ok := <-respCh
 	assert.False(t, ok)
@@ -68,7 +68,7 @@ func TestOpenStreamShouldRetryOnStreamCreationFailure(t *testing.T) {
 				transport.NewRequestV2(&v2.DiscoveryRequest{
 					TypeUrl: url,
 					Node:    &core.Node{},
-				}))
+				}), "aggregated_key")
 			assert.NotNil(t, respCh)
 			for {
 				if v, ok := scope.Snapshot().Counters()[stats[0]]; ok && v.Value() == 1 {
@@ -104,7 +104,7 @@ func TestOpenStreamShouldRetryOnStreamCreationFailureV3(t *testing.T) {
 				transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 					TypeUrl: url,
 					Node:    &corev3.Node{},
-				}))
+				}), "aggregated_key")
 			assert.NotNil(t, respCh)
 			for {
 				if v, ok := scope.Snapshot().Counters()[stats[0]]; ok && v.Value() == 1 {
@@ -130,7 +130,7 @@ func TestOpenStreamShouldReturnNonEmptyResponseChannel(t *testing.T) {
 		transport.NewRequestV2(&v2.DiscoveryRequest{
 			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
-		}))
+		}), "aggregated_key")
 	assert.NotNil(t, respCh)
 
 	done()
@@ -146,7 +146,7 @@ func TestOpenStreamShouldReturnNonEmptyResponseChannelV3(t *testing.T) {
 		transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 			TypeUrl: resourcev3.ListenerType,
 			Node:    &corev3.Node{},
-		}))
+		}), "aggregated_key")
 	assert.NotNil(t, respCh)
 
 	done()
@@ -184,7 +184,7 @@ func TestOpenStreamShouldSendTheFirstRequestToOriginServer(t *testing.T) {
 		transport.NewRequestV2(&v2.DiscoveryRequest{
 			TypeUrl: resource.ListenerType,
 			Node:    node,
-		}))
+		}), "aggregated_key")
 	<-wait
 	assert.NotNil(t, message)
 	assert.Equal(t, message.GetNode(), node)
@@ -225,7 +225,7 @@ func TestOpenStreamShouldSendTheFirstRequestToOriginServerV3(t *testing.T) {
 		transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 			TypeUrl: resourcev3.ListenerType,
 			Node:    node,
-		}))
+		}), "aggregated_key")
 	<-wait
 	assert.NotNil(t, message)
 	assert.Equal(t, message.GetNode(), node)
@@ -267,7 +267,7 @@ func TestOpenStreamShouldClearNackFromRequestInTheFirstRequestToOriginServer(t *
 			TypeUrl:     resource.ListenerType,
 			Node:        node,
 			ErrorDetail: &status.Status{Message: "message", Code: 1},
-		}))
+		}), "aggregated_key")
 	<-wait
 	assert.NotNil(t, message)
 	assert.Equal(t, message.GetNode(), node)
@@ -310,7 +310,7 @@ func TestOpenStreamShouldClearNackFromRequestInTheFirstRequestToOriginServerV3(t
 			TypeUrl:     resourcev3.ListenerType,
 			Node:        node,
 			ErrorDetail: &status.Status{Message: "message", Code: 1},
-		}))
+		}), "aggregated_key")
 	<-wait
 	assert.NotNil(t, message)
 	assert.Equal(t, message.GetNode(), node)
@@ -346,7 +346,7 @@ func TestOpenStreamShouldRetryIfSendFails(t *testing.T) {
 		transport.NewRequestV2(&v2.DiscoveryRequest{
 			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
-		}))
+		}), "aggregated_key")
 	defer done()
 	_, more := <-resp
 	assert.True(t, more)
@@ -382,7 +382,7 @@ func TestOpenStreamShouldRetryIfSendFailsV3(t *testing.T) {
 		transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 			TypeUrl: resourcev3.ListenerType,
 			Node:    &corev3.Node{},
-		}))
+		}), "aggregated_key")
 	_, more := <-resp
 	assert.True(t, more)
 
@@ -411,7 +411,7 @@ func TestOpenStreamShouldSendTheResponseOnTheChannel(t *testing.T) {
 		transport.NewRequestV2(&v2.DiscoveryRequest{
 			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
-		}))
+		}), "aggregated_key")
 	assert.NotNil(t, resp)
 	val := <-resp
 	assert.Equal(t, val.Get().V2, response)
@@ -441,7 +441,7 @@ func TestOpenStreamShouldSendTheResponseOnTheChannelV3(t *testing.T) {
 		transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 			TypeUrl: resourcev3.ListenerType,
 			Node:    &corev3.Node{},
-		}))
+		}), "aggregated_key")
 	assert.NotNil(t, resp)
 	val := <-resp
 	assert.Equal(t, val.Get().V3, response)
@@ -489,7 +489,7 @@ func TestOpenStreamShouldSendTheNextRequestWithUpdatedVersionAndNonce(t *testing
 		transport.NewRequestV2(&v2.DiscoveryRequest{
 			TypeUrl: resource.ListenerType,
 			Node:    &core.Node{},
-		}))
+		}), "aggregated_key")
 	defer done()
 	assert.NotNil(t, resp)
 	for i := 0; i < 5; i++ {
@@ -540,7 +540,7 @@ func TestOpenStreamShouldSendTheNextRequestWithUpdatedVersionAndNonceV3(t *testi
 		transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 			TypeUrl: resourcev3.ListenerType,
 			Node:    &corev3.Node{},
-		}))
+		}), "aggregated_key")
 	assert.NotNil(t, resp)
 	for i := 0; i < 5; i++ {
 		val := <-resp
@@ -579,7 +579,7 @@ func TestOpenStreamShouldRetryWhenSendMsgBlocks(t *testing.T) {
 	respCh, done := client.OpenStream(transport.NewRequestV2(&v2.DiscoveryRequest{
 		TypeUrl: resource.ListenerType,
 		Node:    &core.Node{},
-	}))
+	}), "aggregated_key")
 	resp, ok := <-respCh
 	assert.True(t, ok)
 	assert.Equal(t, resp.Get().V2.VersionInfo, response2.VersionInfo)
@@ -614,7 +614,7 @@ func TestOpenStreamShouldRetryWhenSendMsgBlocksV3(t *testing.T) {
 	respCh, done := client.OpenStream(transport.NewRequestV3(&discoveryv3.DiscoveryRequest{
 		TypeUrl: resourcev3.ListenerType,
 		Node:    &corev3.Node{},
-	}))
+	}), "aggregated_key")
 	resp, ok := <-respCh
 	assert.True(t, ok)
 	assert.Equal(t, response2.VersionInfo, resp.Get().V3.VersionInfo)

--- a/internal/app/upstream/client_test.go
+++ b/internal/app/upstream/client_test.go
@@ -57,10 +57,10 @@ func TestOpenStreamShouldRetryOnStreamCreationFailure(t *testing.T) {
 	client := createMockClientWithError(ctx, scope)
 
 	typeURLs := map[string][]string{
-		resource.ListenerType: {"mock.lds.stream_failure+", "mock.lds.stream_opened+"},
-		resource.ClusterType:  {"mock.cds.stream_failure+", "mock.cds.stream_opened+"},
-		resource.RouteType:    {"mock.rds.stream_failure+", "mock.rds.stream_opened+"},
-		resource.EndpointType: {"mock.eds.stream_failure+", "mock.eds.stream_opened+"},
+		resource.ListenerType: {"mock.lds.stream_failure+key=aggregated_key", "mock.lds.stream_opened+key=aggregated_key"},
+		resource.ClusterType:  {"mock.cds.stream_failure+key=aggregated_key", "mock.cds.stream_opened+key=aggregated_key"},
+		resource.RouteType:    {"mock.rds.stream_failure+key=aggregated_key", "mock.rds.stream_opened+key=aggregated_key"},
+		resource.EndpointType: {"mock.eds.stream_failure+key=aggregated_key", "mock.eds.stream_opened+key=aggregated_key"},
 	}
 	for url, stats := range typeURLs {
 		t.Run(url, func(t *testing.T) {
@@ -93,10 +93,10 @@ func TestOpenStreamShouldRetryOnStreamCreationFailureV3(t *testing.T) {
 	client := createMockClientWithErrorV3(ctx, scope)
 
 	typeURLs := map[string][]string{
-		resourcev3.ListenerType: {"mock.lds.stream_failure+", "mock.lds.stream_opened+"},
-		resourcev3.ClusterType:  {"mock.cds.stream_failure+", "mock.cds.stream_opened+"},
-		resourcev3.RouteType:    {"mock.rds.stream_failure+", "mock.rds.stream_opened+"},
-		resourcev3.EndpointType: {"mock.eds.stream_failure+", "mock.eds.stream_opened+"},
+		resourcev3.ListenerType: {"mock.lds.stream_failure+key=aggregated_key", "mock.lds.stream_opened+key=aggregated_key"},
+		resourcev3.ClusterType:  {"mock.cds.stream_failure+key=aggregated_key", "mock.cds.stream_opened+key=aggregated_key"},
+		resourcev3.RouteType:    {"mock.rds.stream_failure+key=aggregated_key", "mock.rds.stream_opened+key=aggregated_key"},
+		resourcev3.EndpointType: {"mock.eds.stream_failure+key=aggregated_key", "mock.eds.stream_opened+key=aggregated_key"},
 	}
 	for url, stats := range typeURLs {
 		t.Run(url, func(t *testing.T) {


### PR DESCRIPTION
While rolling out xdsrelay in staging, we noticed difficulty in debugging a cache drift between upstream control plane and xdsrelay.
It was hard to associate errors in xdsrelay with the per service cache drift. It would be easy to track errors if we had granular per key stats.

Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>