### PR TITLE
Handle panic

### DIFF
--- a/internal/app/orchestrator/downstream.go
+++ b/internal/app/orchestrator/downstream.go
@@ -31,9 +31,9 @@ func newDownstreamResponseMap() downstreamResponseMap {
 	}
 }
 
-// createChannel initializes a new channel for a request if it doesn't already
+// createWatch initializes a new channel for a request if it doesn't already
 // exist.
-func (d *downstreamResponseMap) createChannel(req transport.Request) transport.Watch {
+func (d *downstreamResponseMap) createWatch(req transport.Request) transport.Watch {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, ok := d.watches[req]; !ok {

--- a/internal/app/orchestrator/downstream.go
+++ b/internal/app/orchestrator/downstream.go
@@ -12,52 +12,41 @@
 package orchestrator
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/envoyproxy/xds-relay/internal/app/mapper"
 	"github.com/envoyproxy/xds-relay/internal/app/transport"
 )
 
-// responseChannel stores the responses to be sent to downstream clients. A
-// WaitGroup is used here to ensure that all writes to the channel are
-// processed before we attempt to close the channel.
-type responseChannel struct {
-	wg    sync.WaitGroup
-	watch transport.Watch
-}
-
 // downstreamResponseMap is a map of downstream xDS client requests to response
 // channels.
 type downstreamResponseMap struct {
-	mu               sync.RWMutex
-	responseChannels map[transport.Request]*responseChannel
+	mu      sync.RWMutex
+	watches map[transport.Request]transport.Watch
 }
 
 func newDownstreamResponseMap() downstreamResponseMap {
 	return downstreamResponseMap{
-		responseChannels: make(map[transport.Request]*responseChannel),
+		watches: make(map[transport.Request]transport.Watch),
 	}
 }
 
 // createChannel initializes a new channel for a request if it doesn't already
 // exist.
-func (d *downstreamResponseMap) createChannel(req transport.Request) *responseChannel {
+func (d *downstreamResponseMap) createChannel(req transport.Request) transport.Watch {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if _, ok := d.responseChannels[req]; !ok {
-		d.responseChannels[req] = &responseChannel{
-			watch: req.CreateWatch(),
-		}
+	if _, ok := d.watches[req]; !ok {
+		d.watches[req] = req.CreateWatch()
 	}
-	return d.responseChannels[req]
+	return d.watches[req]
 }
 
 // get retrieves the channel where responses are set for the specified request.
-func (d *downstreamResponseMap) get(req transport.Request) (*responseChannel, bool) {
+func (d *downstreamResponseMap) get(req transport.Request) (transport.Watch, bool) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
-	channel, ok := d.responseChannels[req]
+	channel, ok := d.watches[req]
 	return channel, ok
 }
 
@@ -66,12 +55,11 @@ func (d *downstreamResponseMap) get(req transport.Request) (*responseChannel, bo
 func (d *downstreamResponseMap) delete(req transport.Request) transport.Watch {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if responseChannel, ok := d.responseChannels[req]; ok {
+	if watch, ok := d.watches[req]; ok {
 		// wait for all writes to the responseChannel to complete before closing.
-		responseChannel.wg.Wait()
-		responseChannel.watch.Close()
-		delete(d.responseChannels, req)
-		return responseChannel.watch
+		watch.Close()
+		delete(d.watches, req)
+		return watch
 	}
 	return nil
 }
@@ -82,11 +70,10 @@ func (d *downstreamResponseMap) deleteAll(watchers map[transport.Request]bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	for watch := range watchers {
-		if responseChannel, ok := d.responseChannels[watch]; ok {
+		if w, ok := d.watches[watch]; ok {
 			// wait for all writes to the responseChannel to complete before closing.
-			responseChannel.wg.Wait()
-			responseChannel.watch.Close()
-			delete(d.responseChannels, watch)
+			w.Close()
+			delete(d.watches, watch)
 		}
 	}
 }
@@ -97,7 +84,7 @@ func (d *downstreamResponseMap) getAggregatedKeys(m *mapper.Mapper) (map[string]
 	defer d.mu.RUnlock()
 	// Since multiple requests can map to the same cache key, we use a map to ensure unique entries.
 	keys := make(map[string]bool)
-	for request := range d.responseChannels {
+	for request := range d.watches {
 		key, err := mapper.Mapper.GetKey(*m, request)
 		if err != nil {
 			return nil, err
@@ -105,14 +92,4 @@ func (d *downstreamResponseMap) getAggregatedKeys(m *mapper.Mapper) (map[string]
 		keys[key] = true
 	}
 	return keys, nil
-}
-
-func (responseChannel *responseChannel) addResponse(resp transport.Response) error {
-	responseChannel.wg.Add(1)
-	defer responseChannel.wg.Done()
-	if ok := responseChannel.watch.Send(resp); ok {
-		return nil
-	}
-
-	return fmt.Errorf("channel is blocked")
 }

--- a/internal/app/orchestrator/downstream_test.go
+++ b/internal/app/orchestrator/downstream_test.go
@@ -27,16 +27,16 @@ var (
 
 func Test_downstreamResponseMap_createChannel(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
-	assert.Equal(t, 0, len(responseMap.responseChannels))
+	assert.Equal(t, 0, len(responseMap.watches))
 	responseMap.createChannel(transport.NewRequestV2(&mockRequest))
-	assert.Equal(t, 1, len(responseMap.responseChannels))
+	assert.Equal(t, 1, len(responseMap.watches))
 }
 
 func Test_downstreamResponseMap_get(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
 	request := transport.NewRequestV2(&mockRequest)
 	responseMap.createChannel(request)
-	assert.Equal(t, 1, len(responseMap.responseChannels))
+	assert.Equal(t, 1, len(responseMap.watches))
 	if _, ok := responseMap.get(request); !ok {
 		t.Error("request not found")
 	}
@@ -50,7 +50,7 @@ func Test_downstreamResponseMap_delete(t *testing.T) {
 	})
 	responseMap.createChannel(request)
 	responseMap.createChannel(request2)
-	assert.Equal(t, 2, len(responseMap.responseChannels))
+	assert.Equal(t, 2, len(responseMap.watches))
 	if _, ok := responseMap.get(request); !ok {
 		t.Error("request not found")
 	}
@@ -58,12 +58,12 @@ func Test_downstreamResponseMap_delete(t *testing.T) {
 		t.Error("request not found")
 	}
 	responseMap.delete(request)
-	assert.Equal(t, 1, len(responseMap.responseChannels))
+	assert.Equal(t, 1, len(responseMap.watches))
 	if _, ok := responseMap.get(request); ok {
 		t.Error("request found, when should be deleted")
 	}
 	responseMap.delete(request2)
-	assert.Equal(t, 0, len(responseMap.responseChannels))
+	assert.Equal(t, 0, len(responseMap.watches))
 }
 
 func Test_downstreamResponseMap_deleteAll(t *testing.T) {
@@ -78,14 +78,14 @@ func Test_downstreamResponseMap_deleteAll(t *testing.T) {
 	responseMap.createChannel(request)
 	responseMap.createChannel(request2)
 	responseMap.createChannel(request3)
-	assert.Equal(t, 3, len(responseMap.responseChannels))
+	assert.Equal(t, 3, len(responseMap.watches))
 	responseMap.deleteAll(
 		map[transport.Request]bool{
 			request:  true,
 			request2: true,
 		},
 	)
-	assert.Equal(t, 1, len(responseMap.responseChannels))
+	assert.Equal(t, 1, len(responseMap.watches))
 	if _, ok := responseMap.get(request); ok {
 		t.Error("request found, when should be deleted")
 	}

--- a/internal/app/orchestrator/downstream_test.go
+++ b/internal/app/orchestrator/downstream_test.go
@@ -25,17 +25,17 @@ var (
 	}
 )
 
-func Test_downstreamResponseMap_createChannel(t *testing.T) {
+func Test_downstreamResponseMap_createWatch(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
 	assert.Equal(t, 0, len(responseMap.watches))
-	responseMap.createChannel(transport.NewRequestV2(&mockRequest))
+	responseMap.createWatch(transport.NewRequestV2(&mockRequest))
 	assert.Equal(t, 1, len(responseMap.watches))
 }
 
 func Test_downstreamResponseMap_get(t *testing.T) {
 	responseMap := newDownstreamResponseMap()
 	request := transport.NewRequestV2(&mockRequest)
-	responseMap.createChannel(request)
+	responseMap.createWatch(request)
 	assert.Equal(t, 1, len(responseMap.watches))
 	if _, ok := responseMap.get(request); !ok {
 		t.Error("request not found")
@@ -48,8 +48,8 @@ func Test_downstreamResponseMap_delete(t *testing.T) {
 	request2 := transport.NewRequestV2(&gcp.Request{
 		TypeUrl: "type.googleapis.com/envoy.api.v2.Cluster",
 	})
-	responseMap.createChannel(request)
-	responseMap.createChannel(request2)
+	responseMap.createWatch(request)
+	responseMap.createWatch(request2)
 	assert.Equal(t, 2, len(responseMap.watches))
 	if _, ok := responseMap.get(request); !ok {
 		t.Error("request not found")
@@ -75,9 +75,9 @@ func Test_downstreamResponseMap_deleteAll(t *testing.T) {
 	request3 := transport.NewRequestV2(&gcp.Request{
 		TypeUrl: "type.googleapis.com/envoy.api.v2.RouteConfiguration",
 	})
-	responseMap.createChannel(request)
-	responseMap.createChannel(request2)
-	responseMap.createChannel(request3)
+	responseMap.createWatch(request)
+	responseMap.createWatch(request2)
+	responseMap.createWatch(request3)
 	assert.Equal(t, 3, len(responseMap.watches))
 	responseMap.deleteAll(
 		map[transport.Request]bool{

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -129,7 +129,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 
 	// If this is the first time we're seeing the request from the
 	// downstream client, initialize a channel to feed future responses.
-	responseChannel := o.downstreamResponseMap.createWatch(req)
+	watch := o.downstreamResponseMap.createWatch(req)
 
 	aggregatedKey, err := o.mapper.GetKey(req)
 	if err != nil {
@@ -197,7 +197,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 		// If we have a cached response and the version is different,
 		// immediately push the result to the response channel.
 		go func() {
-			err := responseChannel.Send(cached.Resp)
+			err := watch.Send(cached.Resp)
 			if err != nil {
 				// Sanity check that the channel isn't blocked. This shouldn't
 				// ever happen since the channel is newly created. Regardless,
@@ -230,7 +230,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 		}
 	}
 
-	return responseChannel, o.onCancelWatch(aggregatedKey, req)
+	return watch, o.onCancelWatch(aggregatedKey, req)
 }
 
 // GetReadOnlyCache returns the request/response cache with only read-only methods exposed.

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -129,7 +129,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 
 	// If this is the first time we're seeing the request from the
 	// downstream client, initialize a channel to feed future responses.
-	responseChannel := o.downstreamResponseMap.createChannel(req)
+	responseChannel := o.downstreamResponseMap.createWatch(req)
 
 	aggregatedKey, err := o.mapper.GetKey(req)
 	if err != nil {

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -197,7 +197,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 		// If we have a cached response and the version is different,
 		// immediately push the result to the response channel.
 		go func() {
-			err := responseChannel.addResponse(cached.Resp)
+			err := responseChannel.Send(cached.Resp)
 			if err != nil {
 				// Sanity check that the channel isn't blocked. This shouldn't
 				// ever happen since the channel is newly created. Regardless,
@@ -230,7 +230,7 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 		}
 	}
 
-	return responseChannel.watch, o.onCancelWatch(aggregatedKey, req)
+	return responseChannel, o.onCancelWatch(aggregatedKey, req)
 }
 
 // GetReadOnlyCache returns the request/response cache with only read-only methods exposed.
@@ -351,7 +351,7 @@ func (o *orchestrator) fanout(resp transport.Response, watchers map[transport.Re
 			defer wg.Done()
 			// TODO https://github.com/envoyproxy/xds-relay/issues/119
 			if channel, ok := o.downstreamResponseMap.get(watch); ok {
-				if err := channel.addResponse(resp); err != nil {
+				if err := channel.Send(resp); err != nil {
 					// If the channel is blocked, we simply drop subsequent
 					// requests and error. Alternative possibilities are
 					// discussed here:

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -143,7 +143,7 @@ func TestGoldenPath(t *testing.T) {
 	assert.EqualValues(
 		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.created+key=%v", aggregatedKey)].Value())
 	assert.NotNil(t, respChannel)
-	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.watches))
 	testutils.AssertSyncMapLen(t, 1, orchestrator.upstreamResponseMap.internal)
 	orchestrator.upstreamResponseMap.internal.Range(func(key, val interface{}) bool {
 		assert.Equal(t, "lds", key.(string))
@@ -176,7 +176,7 @@ func TestGoldenPath(t *testing.T) {
 		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.fanout+key=%v", aggregatedKey)].Value())
 	assert.EqualValues(
 		t, 1, countersSnapshot[fmt.Sprintf("mock_orchestrator.watch.canceled+key=%v", aggregatedKey)].Value())
-	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
 }
 
 func TestUnaggregatedKey(t *testing.T) {
@@ -205,7 +205,7 @@ func TestUnaggregatedKey(t *testing.T) {
 	testutils.AssertCounterValue(t, mockScope.Snapshot().Counters(),
 		"mock_orchestrator.watch.errors.unaggregated_key", 1)
 	assert.NotNil(t, respChannel)
-	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
 	_, more := <-respChannel.GetChannel().V2
 	assert.False(t, more)
 }
@@ -248,7 +248,7 @@ func TestCachedResponse(t *testing.T) {
 
 	respChannel, cancelWatch := orchestrator.CreateWatch(transport.NewRequestV2(&req))
 	assert.NotNil(t, respChannel)
-	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.watches))
 	testutils.AssertSyncMapLen(t, 1, orchestrator.upstreamResponseMap.internal)
 	orchestrator.upstreamResponseMap.internal.Range(func(key, val interface{}) bool {
 		assert.Equal(t, "lds", key.(string))
@@ -287,7 +287,7 @@ func TestCachedResponse(t *testing.T) {
 
 	respChannel2, cancelWatch2 := orchestrator.CreateWatch(transport.NewRequestV2(&req2))
 	assert.NotNil(t, respChannel2)
-	assert.Equal(t, 2, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 2, len(orchestrator.downstreamResponseMap.watches))
 	testutils.AssertSyncMapLen(t, 1, orchestrator.upstreamResponseMap.internal)
 	orchestrator.upstreamResponseMap.internal.Range(func(key, val interface{}) bool {
 		assert.Contains(t, "lds", key.(string))
@@ -302,9 +302,9 @@ func TestCachedResponse(t *testing.T) {
 	testutils.AssertSyncMapLen(t, 0, orchestrator.upstreamResponseMap.internal)
 
 	cancelWatch()
-	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.watches))
 	cancelWatch2()
-	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
 }
 
 func TestMultipleWatchersAndUpstreams(t *testing.T) {
@@ -377,7 +377,7 @@ func TestMultipleWatchersAndUpstreams(t *testing.T) {
 	gotResponseFromChannel2 := <-respChannel2.GetChannel().V2
 	gotResponseFromChannel3 := <-respChannel3.GetChannel().V2
 
-	assert.Equal(t, 3, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 3, len(orchestrator.downstreamResponseMap.watches))
 	testutils.AssertSyncMapLen(t, 2, orchestrator.upstreamResponseMap.internal)
 	orchestrator.upstreamResponseMap.internal.Range(func(key, val interface{}) bool {
 		assert.Contains(t, []string{"lds", "cds"}, key.(string))
@@ -396,7 +396,7 @@ func TestMultipleWatchersAndUpstreams(t *testing.T) {
 	cancelWatch1()
 	cancelWatch2()
 	cancelWatch3()
-	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
 }
 
 func TestUpstreamFailure(t *testing.T) {
@@ -483,7 +483,7 @@ func TestNACKRequest(t *testing.T) {
 
 	respChannel, cancelWatch := orchestrator.CreateWatch(transport.NewRequestV2(&req))
 	assert.NotNil(t, respChannel)
-	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.watches))
 	testutils.AssertSyncMapLen(t, 1, orchestrator.upstreamResponseMap.internal)
 	orchestrator.upstreamResponseMap.internal.Range(func(key, val interface{}) bool {
 		assert.Equal(t, "lds", key.(string))
@@ -518,7 +518,7 @@ func TestNACKRequest(t *testing.T) {
 	orchestrator.shutdown(ctx)
 	testutils.AssertSyncMapLen(t, 0, orchestrator.upstreamResponseMap.internal)
 
-	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 1, len(orchestrator.downstreamResponseMap.watches))
 	cancelWatch()
-	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.responseChannels))
+	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
 }

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -15,5 +15,5 @@ type ChannelVersion struct {
 type Watch interface {
 	Close()
 	GetChannel() *ChannelVersion
-	Send(Response) bool
+	Send(Response) error
 }

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -14,7 +14,7 @@ type ChannelVersion struct {
 // Watch interface abstracts v2 and v3 watches to the downstream sidecars.
 type Watch interface {
 	// Close is idempotent with Send.
-	// When Close and Send are called from separate goroutines they are guarenteed to not panic
+	// When Close and Send are called from separate goroutines they are guaranteed to not panic
 	Close()
 	GetChannel() *ChannelVersion
 	// Send is a mutex protected function to send responses to the downstream sidecars.

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -15,10 +15,10 @@ type ChannelVersion struct {
 type Watch interface {
 	// Close is idempotent with Send.
 	// When Close and Send are called from separate goroutines they are guaranteed to not panic
+	// Close waits until all Send operations drain.
 	Close()
 	GetChannel() *ChannelVersion
 	// Send is a mutex protected function to send responses to the downstream sidecars.
 	// It provides guarantee to never panic when calling in tandem with Close from separate goroutines.
-	// Close waits until all Send operations drain.
 	Send(Response) error
 }

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -11,9 +11,14 @@ type ChannelVersion struct {
 	V3 chan gcpv3.Response
 }
 
-// Watch interface abstracts v2 and v3 watches
+// Watch interface abstracts v2 and v3 watches to the downstream sidecars.
 type Watch interface {
+	// Close is idempotent with Send.
+	// When Close and Send are called from separate goroutines they are guarenteed to not panic
 	Close()
 	GetChannel() *ChannelVersion
+	// Send is a mutex protected function to send responses to the downstream sidecars.
+	// It provides guarantee to never panic when calling in tandem with Close from separate goroutines.
+	// Close waits until all Send operations drain.
 	Send(Response) error
 }

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -31,14 +31,7 @@ var _ = Describe("TestWatch", func() {
 		var wg sync.WaitGroup
 		wg.Add(1)
 		go func() {
-			more := true
-			switch v {
-			case V2:
-				_, more = <-w.GetChannel().V2
-			case V3:
-				_, more = <-w.GetChannel().V3
-			}
-			Expect(more).To(BeFalse())
+			verifyChannelState(v, nil, false, w)
 			wg.Done()
 		}()
 		w.Close()
@@ -52,23 +45,13 @@ var _ = Describe("TestWatch", func() {
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
-			var got interface{}
-			more := false
-			switch v {
-			case V2:
-				got, more = <-w.GetChannel().V2
-			case V3:
-				got, more = <-w.GetChannel().V3
-			}
-
-			Expect(more).To(BeTrue())
-			Expect(got).To(Equal(expected))
+			verifyChannelState(v, expected, true, w)
 			wg.Done()
 		}()
 
 		go func() {
-			ok := w.Send(r)
-			Expect(ok).To(BeTrue())
+			err := w.Send(r)
+			Expect(err).To(BeNil())
 			wg.Done()
 		}()
 		wg.Wait()
@@ -77,14 +60,12 @@ var _ = Describe("TestWatch", func() {
 			"V2",
 			newWatchV2(),
 			NewResponseV2(discoveryRequestv2, discoveryResponsev2),
-			//nolint
 			&cachev2.PassthroughResponse{DiscoveryResponse: discoveryResponsev2, Request: discoveryRequestv2},
 			V2),
 		Entry(
 			"V3",
 			newWatchV3(),
 			NewResponseV3(discoveryRequestv3, discoveryResponsev3),
-			//nolint
 			&cachev3.PassthroughResponse{DiscoveryResponse: discoveryResponsev3, Request: discoveryRequestv3},
 			V3),
 	}...)
@@ -104,12 +85,54 @@ var _ = Describe("TestWatch", func() {
 		Entry("V2", newWatchV2(), NewResponseV2(discoveryRequestv2, discoveryResponsev2)),
 		Entry("V3", newWatchV3(), NewResponseV3(discoveryRequestv3, discoveryResponsev3)),
 	}...)
+
+	DescribeTable("TestNoPanicOnSendAfterClose", func(w Watch, r Response, expected interface{}, v version) {
+		err := w.Send(r)
+		Expect(err).To(BeNil())
+		w.Close()
+		err = w.Send(r)
+		Expect(err).To(BeNil())
+
+		verifyChannelState(v, expected, true, w)
+		verifyChannelState(v, nil, false, w)
+	}, []TableEntry{
+		Entry(
+			"V2",
+			newWatchV2(),
+			NewResponseV2(discoveryRequestv2, discoveryResponsev2),
+			&cachev2.PassthroughResponse{DiscoveryResponse: discoveryResponsev2, Request: discoveryRequestv2},
+			V2),
+		Entry(
+			"V3",
+			newWatchV3(),
+			NewResponseV3(discoveryRequestv3, discoveryResponsev3),
+			&cachev3.PassthroughResponse{DiscoveryResponse: discoveryResponsev3, Request: discoveryRequestv3},
+			V3),
+	}...)
 })
 
 func sendWithCloseChannelOnFailure(w Watch, wg *sync.WaitGroup, r Response) {
-	ok := w.Send(r)
-	if !ok {
+	err := w.Send(r)
+	if err != nil {
 		w.Close()
 	}
 	wg.Done()
+}
+
+func verifyChannelState(v version, expectedResponse interface{}, expectedMore bool, w Watch) {
+	var got interface{}
+	more := false
+
+	switch v {
+	case V2:
+		got, more = <-w.GetChannel().V2
+	case V3:
+		got, more = <-w.GetChannel().V3
+	}
+	Expect(more).To(Equal(expectedMore))
+	if expectedResponse == nil {
+		Expect(got).To(BeNil())
+	} else {
+		Expect(got).To(Equal(expectedResponse))
+	}
 }

--- a/internal/app/transport/watchv2.go
+++ b/internal/app/transport/watchv2.go
@@ -12,7 +12,7 @@ var _ Watch = &watchV2{}
 // WatchV2 is the transport object that takes care of send responses to the xds clients
 type watchV2 struct {
 	out    chan gcpv2.Response
-	mu     sync.Mutex
+	mu     sync.RWMutex
 	closed bool
 }
 
@@ -38,8 +38,8 @@ func (w *watchV2) GetChannel() *ChannelVersion {
 
 // Send sends the xds response over wire
 func (w *watchV2) Send(s Response) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	if w.closed {
 		return nil
 	}

--- a/internal/app/transport/watchv2.go
+++ b/internal/app/transport/watchv2.go
@@ -1,6 +1,9 @@
 package transport
 
 import (
+	"fmt"
+	"sync"
+
 	gcpv2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 )
 
@@ -8,7 +11,9 @@ var _ Watch = &watchV2{}
 
 // WatchV2 is the transport object that takes care of send responses to the xds clients
 type watchV2 struct {
-	out chan gcpv2.Response
+	out    chan gcpv2.Response
+	mu     sync.Mutex
+	closed bool
 }
 
 // newWatchV2 creates a new watch object
@@ -20,6 +25,9 @@ func newWatchV2() Watch {
 
 // Close closes the communication with the xds client
 func (w *watchV2) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
 	close(w.out)
 }
 
@@ -29,11 +37,16 @@ func (w *watchV2) GetChannel() *ChannelVersion {
 }
 
 // Send sends the xds response over wire
-func (w *watchV2) Send(s Response) bool {
+func (w *watchV2) Send(s Response) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
 	select {
 	case w.out <- &gcpv2.PassthroughResponse{DiscoveryResponse: s.Get().V2, Request: s.GetRequest().V2}:
-		return true
+		return nil
 	default:
-		return false
+		return fmt.Errorf("channel is blocked")
 	}
 }

--- a/internal/app/transport/watchv3.go
+++ b/internal/app/transport/watchv3.go
@@ -1,6 +1,9 @@
 package transport
 
 import (
+	"fmt"
+	"sync"
+
 	gcpv3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 )
 
@@ -8,7 +11,9 @@ var _ Watch = &watchV3{}
 
 // WatchV2 is the transport object that takes care of send responses to the xds clients
 type watchV3 struct {
-	out chan gcpv3.Response
+	out    chan gcpv3.Response
+	mu     sync.Mutex
+	closed bool
 }
 
 // newWatchV2 creates a new watch object
@@ -20,6 +25,9 @@ func newWatchV3() Watch {
 
 // Close closes the communication with the xds client
 func (w *watchV3) Close() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
 	close(w.out)
 }
 
@@ -29,11 +37,16 @@ func (w *watchV3) GetChannel() *ChannelVersion {
 }
 
 // Send sends the xds response over wire
-func (w *watchV3) Send(s Response) bool {
+func (w *watchV3) Send(s Response) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.closed {
+		return nil
+	}
 	select {
 	case w.out <- &gcpv3.PassthroughResponse{DiscoveryResponse: s.Get().V3, Request: s.GetRequest().V3}:
-		return true
+		return nil
 	default:
-		return false
+		return fmt.Errorf("channel is blocked")
 	}
 }

--- a/internal/app/transport/watchv3.go
+++ b/internal/app/transport/watchv3.go
@@ -12,7 +12,7 @@ var _ Watch = &watchV3{}
 // WatchV2 is the transport object that takes care of send responses to the xds clients
 type watchV3 struct {
 	out    chan gcpv3.Response
-	mu     sync.Mutex
+	mu     sync.RWMutex
 	closed bool
 }
 
@@ -38,8 +38,8 @@ func (w *watchV3) GetChannel() *ChannelVersion {
 
 // Send sends the xds response over wire
 func (w *watchV3) Send(s Response) error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
+	w.mu.RLock()
+	defer w.mu.RUnlock()
 	if w.closed {
 		return nil
 	}


### PR DESCRIPTION
While rolling xdsrelay for. t1 services, we discovered that there are some edge cases during which send happens on closed channel.
```
  | Nov 5, 2020 @ 11:16:55.595 | child exited

  | Nov 5, 2020 @ 11:16:55.595 | panic stacktrace

  | Nov 5, 2020 @ 11:16:55.595 | child process exited with error

  | Nov 5, 2020 @ 11:16:55.595 | error waiting for child process to exit

  | Nov 5, 2020 @ 11:16:55.595 | wrap exited

  | Nov 5, 2020 @ 11:16:55.592 | ignoring signal: SIGCHLD

  | Nov 5, 2020 @ 11:16:55.576 | -

  | Nov 5, 2020 @ 11:16:55.576 | /code/xds-relay-private/xds-relay/internal/app/transport/watchv3.go:34 +0xd3

  | Nov 5, 2020 @ 11:16:55.576 | github.com/envoyproxy/xds-relay/internal/app/transport.(*watchV3).Send(0xc003e9c7a8, 0x1034080, 0xc0023f5e80, 0x1034080)

  | Nov 5, 2020 @ 11:16:55.576 | /code/xds-relay-private/xds-relay/internal/app/orchestrator/downstream.go:113 +0x90

  | Nov 5, 2020 @ 11:16:55.576 | panic: send on closed channel

  | Nov 5, 2020 @ 11:16:55.576 | /code/xds-relay-private/xds-relay/internal/app/orchestrator/orchestrator.go:199 +0x11a6

  | Nov 5, 2020 @ 11:16:55.576 | goroutine 11600 [running]:

  | Nov 5, 2020 @ 11:16:55.576 | github.com/envoyproxy/xds-relay/internal/app/orchestrator.(*responseChannel).addResponse(0xc003129000, 0x1034080, 0xc0023f5e80, 0x0, 0x0)

  | Nov 5, 2020 @ 11:16:55.576 | github.com/envoyproxy/xds-relay/internal/app/orchestrator.(*orchestrator).CreateWatch.func1(0xc003129000, 0xc002e7ff80, 0xc000481200, 0xc003b66a00, 0x17)

  | Nov 5, 2020 @ 11:16:55.576 | detected panic prefix

  | Nov 5, 2020 @ 11:16:55.576 | created by github.com/envoyproxy/xds-relay/internal/app/orchestrator.(*orchestrator).CreateWatch

  | Nov 5, 2020 @ 11:16:55.576 | /code/xds-relay-private/xds-relay/internal/app/orchestrator/orchestrator.go:200 +0x45

```

Upon investigation, we found that due to the highly ephemeral and concurrent nature of sidecar watches, its possible that `cancelWatch` is called while send is happening. We already have a `waitGroup` based locking, but its not providing protection. The lock should be as close as possible to the critical section.

I'm proposing that we depend on a mutex to coordinate between channel close and send. Go does not provide any guarantees around it[[ref1](https://github.com/golang/go/issues/27769), [ref2](https://github.com/golang/go/issues/30372)]. 

Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>