### PR TITLE
Add ready endpoint

### DIFF
--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -34,6 +34,12 @@ func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 			true,
 		},
 		{
+			"/ready",
+			"ready endpoint. usage: GET /ready POST /ready/true or ready/false",
+			readyHandler(),
+			true,
+		},
+		{
 			"/cache",
 			"print cache entry for a given key. Omitting the key outputs all cache entries. usage: `/cache/<key>`",
 			cacheDumpHandler(orchestrator),

--- a/internal/app/admin/http/ready.go
+++ b/internal/app/admin/http/ready.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"sync"
+
+	"github.com/envoyproxy/xds-relay/internal/pkg/util/stringify"
+	"github.com/envoyproxy/xds-relay/pkg/marshallable"
+)
+
+func readyHandler() http.HandlerFunc {
+	ready := true
+	var mu sync.Mutex
+	return func(w http.ResponseWriter, req *http.Request) {
+		switch req.Method {
+		case http.MethodGet:
+			mu.Lock()
+			defer mu.Unlock()
+			if ready {
+				w.WriteHeader(http.StatusOK)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+			return
+		case http.MethodPost:
+			desiredFromURL := filepath.Base(req.URL.Path)
+			desired, err := strconv.ParseBool(desiredFromURL)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				s, _ := stringify.InterfaceToString(&marshallable.Error{
+					Message: "Only true/false values accepted for ready endpoint",
+				})
+				_, _ = w.Write([]byte(s))
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			ready = desired
+			return
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}
+}

--- a/internal/app/admin/http/ready.go
+++ b/internal/app/admin/http/ready.go
@@ -38,6 +38,7 @@ func readyHandler() http.HandlerFunc {
 			mu.Lock()
 			defer mu.Unlock()
 			ready = desired
+			w.WriteHeader(http.StatusOK)
 			return
 		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)

--- a/internal/app/admin/http/ready_test.go
+++ b/internal/app/admin/http/ready_test.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInvalidHTTPMethod(t *testing.T) {
+	req, err := http.NewRequest("PUT", "/ready/true", nil)
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := readyHandler()
+
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestDefaultReadyStatus(t *testing.T) {
+	req, err := http.NewRequest("GET", "/ready", nil)
+	assert.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	handler := readyHandler()
+
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestReadyOverride(t *testing.T) {
+	req, err := http.NewRequest("POST", "/ready/false", nil)
+	assert.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler := readyHandler()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	req, err = http.NewRequest("GET", "/ready", nil)
+	assert.NoError(t, err)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestMalformedReady(t *testing.T) {
+	req, err := http.NewRequest("POST", "/ready/malformed", nil)
+	assert.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler := readyHandler()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	req, err = http.NewRequest("POST", "/ready/", nil)
+	assert.NoError(t, err)
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}

--- a/internal/app/admin/http/ready_test.go
+++ b/internal/app/admin/http/ready_test.go
@@ -40,8 +40,21 @@ func TestReadyOverride(t *testing.T) {
 
 	req, err = http.NewRequest("GET", "/ready", nil)
 	assert.NoError(t, err)
+	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	req, err = http.NewRequest("POST", "/ready/true", nil)
+	assert.NoError(t, err)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	req, err = http.NewRequest("GET", "/ready", nil)
+	assert.NoError(t, err)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestMalformedReady(t *testing.T) {
@@ -54,6 +67,7 @@ func TestMalformedReady(t *testing.T) {
 
 	req, err = http.NewRequest("POST", "/ready/", nil)
 	assert.NoError(t, err)
+	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 }


### PR DESCRIPTION
While rolling out in staging we realized that there are sometimes cx issues due to which there is cache mismatch between upstream and xdsrelay. Due to the severity of traffic we end up terminating the erroneous pod. We need a way to web off faulty pods to continue investigating the issue.

Signed-off-by: Jyoti Mahapatra <jmahapatra@lyft.com>