### PR TITLE
Dequeue stale responses

### DIFF
--- a/internal/app/metrics/metrics.go
+++ b/internal/app/metrics/metrics.go
@@ -27,6 +27,7 @@ const (
 	OrchestratorNackWatchCreated = "created_nack" // counter, # of watches created per aggregated key in NACK requests
 	OrchestratorWatchCanceled    = "canceled"     // counter, # of watch cancels initiated per aggregated key
 	OrchestratorWatchFanouts     = "fanout"       // counter, # of responses pushed downstream
+	OrchestratorWatchDequeued    = "dequeued"     // counter, # of responses dequeued from the response channel
 
 	// scope: .orchestrator.$aggregated_key.cache_evict.*
 	ScopeOrchestratorCacheEvict            = "cache_evict"

--- a/internal/app/orchestrator/downstream.go
+++ b/internal/app/orchestrator/downstream.go
@@ -17,6 +17,7 @@ import (
 	"github.com/envoyproxy/xds-relay/internal/app/cache"
 	"github.com/envoyproxy/xds-relay/internal/app/mapper"
 	"github.com/envoyproxy/xds-relay/internal/app/transport"
+	"github.com/uber-go/tally"
 )
 
 // downstreamResponseMap is a map of downstream xDS client requests to response
@@ -34,11 +35,11 @@ func newDownstreamResponseMap() downstreamResponseMap {
 
 // createWatch initializes a new channel for a request if it doesn't already
 // exist.
-func (d *downstreamResponseMap) createWatch(req transport.Request) transport.Watch {
+func (d *downstreamResponseMap) createWatch(req transport.Request, scope tally.Scope) transport.Watch {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if _, ok := d.watches[req]; !ok {
-		d.watches[req] = req.CreateWatch()
+		d.watches[req] = req.CreateWatch(scope)
 	}
 	return d.watches[req]
 }

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -128,23 +128,22 @@ func New(
 func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func()) {
 	ctx := context.Background()
 
-	// If this is the first time we're seeing the request from the
-	// downstream client, initialize a channel to feed future responses.
-	watch := o.downstreamResponseMap.createWatch(req)
-
 	aggregatedKey, err := o.mapper.GetKey(req)
 	if err != nil {
+		// TODO (https://github.com/envoyproxy/xds-relay/issues/56)
+		// Support unnaggregated keys.
 		// Can't map the request to an aggregated key. Log error and return.
 		o.logger.With(
 			"error", err,
 			"request_type", req.GetTypeURL(),
 			"node_id", req.GetNodeID(),
 		).Error(ctx, "failed to map to aggregated key")
-
-		// TODO (https://github.com/envoyproxy/xds-relay/issues/56)
-		// Support unnaggregated keys.
-		return o.downstreamResponseMap.delete(req), nil
+		return nil, nil
 	}
+
+	// If this is the first time we're seeing the request from the
+	// downstream client, initialize a channel to feed future responses.
+	watch := o.downstreamResponseMap.createWatch(req, metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey))
 
 	o.logger.With(
 		"node_id", req.GetNodeID(),

--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -129,6 +129,9 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 	ctx := context.Background()
 
 	aggregatedKey, err := o.mapper.GetKey(req)
+	// If this is the first time we're seeing the request from the
+	// downstream client, initialize a channel to feed future responses.
+	watch := o.downstreamResponseMap.createWatch(req, metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey))
 	if err != nil {
 		// TODO (https://github.com/envoyproxy/xds-relay/issues/56)
 		// Support unnaggregated keys.
@@ -138,12 +141,8 @@ func (o *orchestrator) CreateWatch(req transport.Request) (transport.Watch, func
 			"request_type", req.GetTypeURL(),
 			"node_id", req.GetNodeID(),
 		).Error(ctx, "failed to map to aggregated key")
-		return nil, nil
+		return o.downstreamResponseMap.delete(req), nil
 	}
-
-	// If this is the first time we're seeing the request from the
-	// downstream client, initialize a channel to feed future responses.
-	watch := o.downstreamResponseMap.createWatch(req, metrics.OrchestratorWatchSubscope(o.scope, aggregatedKey))
 
 	o.logger.With(
 		"node_id", req.GetNodeID(),

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -208,8 +208,10 @@ func TestUnaggregatedKey(t *testing.T) {
 	assert.Error(t, err)
 
 	respChannel, _ := orchestrator.CreateWatch(req)
-	assert.Nil(t, respChannel)
+	assert.NotNil(t, respChannel)
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
+	_, more := <-respChannel.GetChannel().V2
+	assert.False(t, more)
 }
 
 func TestCachedResponse(t *testing.T) {

--- a/internal/app/orchestrator/orchestrator_test.go
+++ b/internal/app/orchestrator/orchestrator_test.go
@@ -208,10 +208,8 @@ func TestUnaggregatedKey(t *testing.T) {
 	assert.Error(t, err)
 
 	respChannel, _ := orchestrator.CreateWatch(req)
-	assert.NotNil(t, respChannel)
+	assert.Nil(t, respChannel)
 	assert.Equal(t, 0, len(orchestrator.downstreamResponseMap.watches))
-	_, more := <-respChannel.GetChannel().V2
-	assert.False(t, more)
 }
 
 func TestCachedResponse(t *testing.T) {

--- a/internal/app/transport/request.go
+++ b/internal/app/transport/request.go
@@ -4,6 +4,7 @@ import (
 	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/uber-go/tally"
 	status "google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -32,5 +33,5 @@ type Request interface {
 	GetLocality() *Locality
 	GetResponseNonce() string
 	GetRaw() *RequestVersion
-	CreateWatch() Watch
+	CreateWatch(scope tally.Scope) Watch
 }

--- a/internal/app/transport/request_test.go
+++ b/internal/app/transport/request_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/envoyproxy/xds-relay/internal/pkg/stats"
 )
 
 const (
@@ -125,8 +127,9 @@ func TestGetRaw(t *testing.T) {
 func TestCreateWatch(t *testing.T) {
 	requestv2 := NewRequestV2(&requestV2)
 	requestv3 := NewRequestV3(&requestV3)
-	assert.NotNil(t, requestv2.CreateWatch().GetChannel().V2)
-	assert.NotNil(t, requestv2.CreateWatch().GetChannel().V2)
-	assert.Nil(t, requestv2.CreateWatch().GetChannel().V3)
-	assert.Nil(t, requestv3.CreateWatch().GetChannel().V2)
+	scope := stats.NewMockScope("mockwatch")
+	assert.NotNil(t, requestv2.CreateWatch(scope).GetChannel().V2)
+	assert.NotNil(t, requestv2.CreateWatch(scope).GetChannel().V2)
+	assert.Nil(t, requestv2.CreateWatch(scope).GetChannel().V3)
+	assert.Nil(t, requestv3.CreateWatch(scope).GetChannel().V2)
 }

--- a/internal/app/transport/requestv2.go
+++ b/internal/app/transport/requestv2.go
@@ -3,6 +3,7 @@ package transport
 import (
 	discoveryv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/uber-go/tally"
 	status "google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -79,6 +80,6 @@ func (r *RequestV2) GetResponseNonce() string {
 }
 
 // CreateWatch creates a versioned Watch
-func (r *RequestV2) CreateWatch() Watch {
-	return newWatchV2()
+func (r *RequestV2) CreateWatch(scope tally.Scope) Watch {
+	return newWatchV2(scope)
 }

--- a/internal/app/transport/requestv3.go
+++ b/internal/app/transport/requestv3.go
@@ -3,6 +3,7 @@ package transport
 import (
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/uber-go/tally"
 	status "google.golang.org/genproto/googleapis/rpc/status"
 )
 
@@ -79,6 +80,6 @@ func (r *RequestV3) GetResponseNonce() string {
 }
 
 // CreateWatch creates a versioned Watch
-func (r *RequestV3) CreateWatch() Watch {
-	return newWatchV3()
+func (r *RequestV3) CreateWatch(scope tally.Scope) Watch {
+	return newWatchV3(scope)
 }

--- a/internal/app/transport/watch.go
+++ b/internal/app/transport/watch.go
@@ -19,6 +19,8 @@ type Watch interface {
 	Close()
 	GetChannel() *ChannelVersion
 	// Send is a mutex protected function to send responses to the downstream sidecars.
-	// It provides guarantee to never panic when calling in tandem with Close from separate goroutines.
+	// It provides guarantee to never panic when called in tandem with Close from separate
+	// goroutines. This also guarantees that stale responses are dropped in the event that a
+	// newer response arrives.
 	Send(Response) error
 }

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -12,6 +12,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+
+	"github.com/envoyproxy/xds-relay/internal/pkg/stats"
 )
 
 type version int
@@ -23,8 +25,13 @@ const (
 
 var discoveryResponsev2 = &discoveryv2.DiscoveryResponse{}
 var discoveryResponsev3 = &discoveryv3.DiscoveryResponse{}
+var discoveryResponse2v2 = &discoveryv2.DiscoveryResponse{TypeUrl: "type.googleapis.com/envoy.api.v2.Listener"}
+var discoveryResponse2v3 = &discoveryv3.DiscoveryResponse{TypeUrl: "type.googleapis.com/envoy.api.v3.Listener"}
 var discoveryRequestv2 = &gcp.Request{}
 var discoveryRequestv3 = &gcpv3.Request{}
+var discoveryRequest2v2 = &gcp.Request{TypeUrl: "type.googleapis.com/envoy.api.v2.Listener"}
+var discoveryRequest2v3 = &gcpv3.Request{TypeUrl: "type.googleapis.com/envoy.api.v3.Listener"}
+var mockScope = stats.NewMockScope("mockwatch")
 
 var _ = Describe("TestWatch", func() {
 	DescribeTable("TestGetChannel", func(w Watch, v version) {
@@ -37,8 +44,8 @@ var _ = Describe("TestWatch", func() {
 		w.Close()
 		wg.Wait()
 	}, []TableEntry{
-		Entry("V2", newWatchV2(), V2),
-		Entry("V3", newWatchV3(), V3),
+		Entry("V2", newWatchV2(mockScope), V2),
+		Entry("V3", newWatchV3(mockScope), V3),
 	}...)
 
 	DescribeTable("TestSendSuccessful", func(w Watch, r Response, expected interface{}, v version) {
@@ -58,13 +65,13 @@ var _ = Describe("TestWatch", func() {
 	}, []TableEntry{
 		Entry(
 			"V2",
-			newWatchV2(),
+			newWatchV2(mockScope),
 			NewResponseV2(discoveryRequestv2, discoveryResponsev2),
 			&cachev2.PassthroughResponse{DiscoveryResponse: discoveryResponsev2, Request: discoveryRequestv2},
 			V2),
 		Entry(
 			"V3",
-			newWatchV3(),
+			newWatchV3(mockScope),
 			NewResponseV3(discoveryRequestv3, discoveryResponsev3),
 			&cachev3.PassthroughResponse{DiscoveryResponse: discoveryResponsev3, Request: discoveryRequestv3},
 			V3),
@@ -82,8 +89,8 @@ var _ = Describe("TestWatch", func() {
 		go sendWithCloseChannelOnFailure(w, &wg, resp)
 		wg.Wait()
 	}, []TableEntry{
-		Entry("V2", newWatchV2(), NewResponseV2(discoveryRequestv2, discoveryResponsev2)),
-		Entry("V3", newWatchV3(), NewResponseV3(discoveryRequestv3, discoveryResponsev3)),
+		Entry("V2", newWatchV2(mockScope), NewResponseV2(discoveryRequestv2, discoveryResponsev2)),
+		Entry("V3", newWatchV3(mockScope), NewResponseV3(discoveryRequestv3, discoveryResponsev3)),
 	}...)
 
 	DescribeTable("TestNoPanicOnSendAfterClose", func(w Watch, r Response, expected interface{}, v version) {
@@ -98,15 +105,45 @@ var _ = Describe("TestWatch", func() {
 	}, []TableEntry{
 		Entry(
 			"V2",
-			newWatchV2(),
+			newWatchV2(mockScope),
 			NewResponseV2(discoveryRequestv2, discoveryResponsev2),
 			&cachev2.PassthroughResponse{DiscoveryResponse: discoveryResponsev2, Request: discoveryRequestv2},
 			V2),
 		Entry(
 			"V3",
-			newWatchV3(),
+			newWatchV3(mockScope),
 			NewResponseV3(discoveryRequestv3, discoveryResponsev3),
 			&cachev3.PassthroughResponse{DiscoveryResponse: discoveryResponsev3, Request: discoveryRequestv3},
+			V3),
+	}...)
+
+	DescribeTable("TestSendDequeue", func(w Watch, r, r2 Response, expected interface{}, v version) {
+		// Send two responses in sequence. The second one should be dequeued.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		err := w.Send(r)
+		Expect(err).To(BeNil())
+		wg.Done()
+		err = w.Send(r2)
+		Expect(err).To(BeNil())
+		wg.Done()
+		wg.Wait()
+
+		verifyChannelState(v, expected, true, w)
+	}, []TableEntry{
+		Entry(
+			"V2",
+			newWatchV2(mockScope),
+			NewResponseV2(discoveryRequestv2, discoveryResponsev2),
+			NewResponseV2(discoveryRequest2v2, discoveryResponse2v2),
+			&cachev2.PassthroughResponse{DiscoveryResponse: discoveryResponse2v2, Request: discoveryRequest2v2},
+			V2),
+		Entry(
+			"V3",
+			newWatchV3(mockScope),
+			NewResponseV3(discoveryRequestv3, discoveryResponsev3),
+			NewResponseV3(discoveryRequest2v3, discoveryResponse2v3),
+			&cachev3.PassthroughResponse{DiscoveryResponse: discoveryResponse2v3, Request: discoveryRequest2v3},
 			V3),
 	}...)
 })

--- a/internal/app/transport/watch_test.go
+++ b/internal/app/transport/watch_test.go
@@ -9,6 +9,8 @@ import (
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	gcpv3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	resourcev2 "github.com/envoyproxy/go-control-plane/pkg/resource/v2"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -25,12 +27,12 @@ const (
 
 var discoveryResponsev2 = &discoveryv2.DiscoveryResponse{}
 var discoveryResponsev3 = &discoveryv3.DiscoveryResponse{}
-var discoveryResponse2v2 = &discoveryv2.DiscoveryResponse{TypeUrl: "type.googleapis.com/envoy.api.v2.Listener"}
-var discoveryResponse2v3 = &discoveryv3.DiscoveryResponse{TypeUrl: "type.googleapis.com/envoy.api.v3.Listener"}
+var discoveryResponse2v2 = &discoveryv2.DiscoveryResponse{TypeUrl: resourcev2.ListenerType}
+var discoveryResponse2v3 = &discoveryv3.DiscoveryResponse{TypeUrl: resourcev3.ListenerType}
 var discoveryRequestv2 = &gcp.Request{}
 var discoveryRequestv3 = &gcpv3.Request{}
-var discoveryRequest2v2 = &gcp.Request{TypeUrl: "type.googleapis.com/envoy.api.v2.Listener"}
-var discoveryRequest2v3 = &gcpv3.Request{TypeUrl: "type.googleapis.com/envoy.api.v3.Listener"}
+var discoveryRequest2v2 = &gcp.Request{TypeUrl: resourcev2.ListenerType}
+var discoveryRequest2v3 = &gcpv3.Request{TypeUrl: resourcev3.ListenerType}
 var mockScope = stats.NewMockScope("mockwatch")
 
 var _ = Describe("TestWatch", func() {

--- a/internal/app/transport/watchv2.go
+++ b/internal/app/transport/watchv2.go
@@ -5,6 +5,9 @@ import (
 	"sync"
 
 	gcpv2 "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
+	"github.com/uber-go/tally"
+
+	"github.com/envoyproxy/xds-relay/internal/app/metrics"
 )
 
 var _ Watch = &watchV2{}
@@ -14,12 +17,15 @@ type watchV2 struct {
 	out    chan gcpv2.Response
 	mu     sync.RWMutex
 	closed bool
+
+	scope tally.Scope
 }
 
 // newWatchV2 creates a new watch object
-func newWatchV2() Watch {
+func newWatchV2(scope tally.Scope) Watch {
 	return &watchV2{
-		out: make(chan gcpv2.Response, 1),
+		out:   make(chan gcpv2.Response, 1),
+		scope: scope,
 	}
 }
 
@@ -43,10 +49,22 @@ func (w *watchV2) Send(s Response) error {
 	if w.closed {
 		return nil
 	}
+
+	// Drop the older response currently in the transport queue, so that we
+	// always send the latest response. Normally, we should hit the default
+	// case (channel is empty), but there are times when the response fanout
+	// is slower than receiving of a new upstream response.
+	select {
+	case <-w.out:
+		w.scope.Counter(metrics.OrchestratorWatchDequeued).Inc(1)
+	default:
+	}
+
 	select {
 	case w.out <- &gcpv2.PassthroughResponse{DiscoveryResponse: s.Get().V2, Request: s.GetRequest().V2}:
 		return nil
 	default:
+		// sanity check, should never happen because of the dequeue above.
 		return fmt.Errorf("channel is blocked")
 	}
 }

--- a/internal/app/transport/watchv3.go
+++ b/internal/app/transport/watchv3.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 
 	gcpv3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	"github.com/envoyproxy/xds-relay/internal/app/metrics"
+	"github.com/uber-go/tally"
 )
 
 var _ Watch = &watchV3{}
@@ -14,12 +16,15 @@ type watchV3 struct {
 	out    chan gcpv3.Response
 	mu     sync.RWMutex
 	closed bool
+
+	scope tally.Scope
 }
 
 // newWatchV2 creates a new watch object
-func newWatchV3() Watch {
+func newWatchV3(scope tally.Scope) Watch {
 	return &watchV3{
-		out: make(chan gcpv3.Response, 1),
+		out:   make(chan gcpv3.Response, 1),
+		scope: scope,
 	}
 }
 
@@ -43,10 +48,22 @@ func (w *watchV3) Send(s Response) error {
 	if w.closed {
 		return nil
 	}
+
+	// Drop the older response currently in the transport queue, so that we
+	// always send the latest response. Normally, we should hit the default
+	// case (channel is empty), but there are times when the response fanout
+	// is slower than receiving of a new upstream response.
+	select {
+	case <-w.out:
+		w.scope.Counter(metrics.OrchestratorWatchDequeued).Inc(1)
+	default:
+	}
+
 	select {
 	case w.out <- &gcpv3.PassthroughResponse{DiscoveryResponse: s.Get().V3, Request: s.GetRequest().V3}:
 		return nil
 	default:
+		// sanity check, should never happen because of the dequeue above.
 		return fmt.Errorf("channel is blocked")
 	}
 }


### PR DESCRIPTION
When sending the response to clients, drop the older response currently
in the transport queue, so that we always send the latest response.

Also,
* Add stats scope to watch / transport layer
* Return nil in unaggregated key scenario

Signed-off-by: Jess Yuen <jyuen@lyft.com>