### PR TITLE
Clear Cache Endpoint Params

### DIFF
--- a/internal/app/admin/http/cache.go
+++ b/internal/app/admin/http/cache.go
@@ -189,7 +189,7 @@ func keyDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 
 func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		cacheKey := getParam(req.URL.Path, "/cache")
+		cacheKey := getParam(req.URL.Path, cacheUrl)
 		c := orchestrator.Orchestrator.GetReadOnlyCache(*o)
 		keysToPrint, err := getRelevantKeys(o, cacheKey, w)
 		if err == nil {
@@ -201,7 +201,7 @@ func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 func clearCacheHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPost {
-			cacheKey := getParam(req.URL.Path, "/cache/clear")
+			cacheKey := getParam(req.URL.Path, clearUrl)
 			keysToClear, err := getRelevantKeys(o, cacheKey, w)
 			if err == nil {
 				clearCacheEntries(keysToClear, o, w)

--- a/internal/app/admin/http/cache.go
+++ b/internal/app/admin/http/cache.go
@@ -201,7 +201,11 @@ func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 func clearCacheHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPost {
-			cacheKey := getParam(req.URL.Path)
+			var cacheKey string
+			splitPath := strings.SplitN(req.URL.Path, "/", 4)
+			if len(splitPath) == 4 {
+				cacheKey = splitPath[3]
+			}
 			keysToClear, err := getRelevantKeys(o, cacheKey, w)
 			if err == nil {
 				clearCacheEntries(keysToClear, o, w)

--- a/internal/app/admin/http/cache.go
+++ b/internal/app/admin/http/cache.go
@@ -189,7 +189,7 @@ func keyDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 
 func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		cacheKey := getParam(req.URL.Path)
+		cacheKey := getParam(req.URL.Path, "/cache")
 		c := orchestrator.Orchestrator.GetReadOnlyCache(*o)
 		keysToPrint, err := getRelevantKeys(o, cacheKey, w)
 		if err == nil {
@@ -201,11 +201,7 @@ func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 func clearCacheHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPost {
-			var cacheKey string
-			splitPath := strings.SplitN(req.URL.Path, "/", 4)
-			if len(splitPath) == 4 {
-				cacheKey = splitPath[3]
-			}
+			cacheKey := getParam(req.URL.Path, "/cache/clear")
 			keysToClear, err := getRelevantKeys(o, cacheKey, w)
 			if err == nil {
 				clearCacheEntries(keysToClear, o, w)

--- a/internal/app/admin/http/cache.go
+++ b/internal/app/admin/http/cache.go
@@ -189,7 +189,7 @@ func keyDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 
 func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		cacheKey := getParam(req.URL.Path, cacheUrl)
+		cacheKey := getParam(req.URL.Path, cacheURL)
 		c := orchestrator.Orchestrator.GetReadOnlyCache(*o)
 		keysToPrint, err := getRelevantKeys(o, cacheKey, w)
 		if err == nil {
@@ -201,7 +201,7 @@ func cacheDumpHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 func clearCacheHandler(o *orchestrator.Orchestrator) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == http.MethodPost {
-			cacheKey := getParam(req.URL.Path, clearUrl)
+			cacheKey := getParam(req.URL.Path, clearURL)
 			keysToClear, err := getRelevantKeys(o, cacheKey, w)
 			if err == nil {
 				clearCacheEntries(keysToClear, o, w)

--- a/internal/app/admin/http/cache_test.go
+++ b/internal/app/admin/http/cache_test.go
@@ -747,7 +747,7 @@ func TestAdminServer_ClearCacheHandler(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(cacheKeys), 1)
 
-	req, err := http.NewRequest("POST", "/clear_cache/test_lds", nil)
+	req, err := http.NewRequest("POST", "/cache/clear/test_lds", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -783,7 +783,7 @@ func TestAdminServer_ClearCacheHandler_NotFound(t *testing.T) {
 	orchestrator := orchestrator.NewMock(t, mapper, client, mockScope)
 	assert.NotNil(t, orchestrator)
 
-	req, err := http.NewRequest("POST", "/clear_cache/cds", nil)
+	req, err := http.NewRequest("POST", "/cache/clear/cds", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -902,15 +902,15 @@ func testAdminServerClearCacheHelper(t *testing.T, urls []string, expectedCacheC
 }
 
 func TestAdminServer_ClearCacheHandler_EntireCache(t *testing.T) {
-	testAdminServerClearCacheHelper(t, []string{"/clear_cache", "/clear_cache/", "/clear_cache/*"}, 0)
+	testAdminServerClearCacheHelper(t, []string{"/cache/clear", "/cache/clear/", "/cache/clear/*"}, 0)
 }
 
 func TestAdminServer_ClearCacheHandler_WildcardSuffix(t *testing.T) {
-	testAdminServerClearCacheHelper(t, []string{"/clear_cache/t*", "/clear_cache/tes*", "/clear_cache/test*"}, 0)
+	testAdminServerClearCacheHelper(t, []string{"/cache/clear/t*", "/cache/clear/tes*", "/cache/clear/test*"}, 0)
 }
 
 func TestAdminServer_ClearCacheHandler_WildcardSuffix_NotFound(t *testing.T) {
-	testAdminServerClearCacheHelper(t, []string{"/clear_cache/b*", "/clear_cache/tesa*", "/clear_cache/t*est*"}, 2)
+	testAdminServerClearCacheHelper(t, []string{"/cache/clear/b*", "/cache/clear/tesa*", "/cache/clear/t*est*"}, 2)
 }
 
 // V3 Clear Cache Handler tests
@@ -1019,11 +1019,11 @@ func testAdminServerClearCacheHelperV3(t *testing.T, urls []string) {
 }
 
 func TestAdminServer_ClearCacheHandler_EntireCacheV3(t *testing.T) {
-	testAdminServerClearCacheHelperV3(t, []string{"/clear_cache", "/clear_cache/", "/clear_cache/*"})
+	testAdminServerClearCacheHelperV3(t, []string{"/cache/clear", "/cache/clear/", "/cache/clear/*"})
 }
 
 func TestAdminServer_ClearCacheHandler_WildcardSuffixV3(t *testing.T) {
-	testAdminServerClearCacheHelperV3(t, []string{"/clear_cache/t*", "/clear_cache/tes*", "/clear_cache/test*"})
+	testAdminServerClearCacheHelperV3(t, []string{"/cache/clear/t*", "/cache/clear/tes*", "/cache/clear/test*"})
 }
 
 func verifyCacheOutput(t *testing.T, rr *httptest.ResponseRecorder, cdsFile string, ldsFile string) {

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -24,9 +24,9 @@ type Handler struct {
 	redirect    bool
 }
 
-const logUrl = "/log_level"
-const cacheUrl = "/cache"
-const clearUrl = "/cache/clear"
+const logURL = "/log_level"
+const cacheURL = "/cache"
+const clearURL = "/cache/clear"
 
 func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 	orchestrator *orchestrator.Orchestrator,
@@ -46,13 +46,13 @@ func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 			true,
 		},
 		{
-			clearUrl,
+			clearURL,
 			"clear cache entry for a given key. Omitting the key clears all cache entries. usage: `/cache/clear/<key>`",
 			clearCacheHandler(orchestrator),
 			true,
 		},
 		{
-			cacheUrl,
+			cacheURL,
 			"print cache entry for a given key. Omitting the key outputs all cache entries. usage: `/cache/<key>`",
 			cacheDumpHandler(orchestrator),
 			true,
@@ -76,7 +76,7 @@ func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 			true,
 		},
 		{
-			logUrl,
+			logURL,
 			"update the log level to `debug`, `info`, `warn`, or `error`. " +
 				"Omitting the level outputs the current log level. usage: `/log_level/<level>`",
 			logLevelHandler(logger),
@@ -166,7 +166,7 @@ func getParam(path string, prefix string) string {
 func logLevelHandler(l log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "POST" {
-			logLevel := getParam(req.URL.Path, logUrl)
+			logLevel := getParam(req.URL.Path, logURL)
 
 			// If no key is provided, output the current log level.
 			if logLevel == "" {

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -24,6 +24,10 @@ type Handler struct {
 	redirect    bool
 }
 
+const logUrl = "/log_level"
+const cacheUrl = "/cache"
+const clearUrl = "/cache/clear"
+
 func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 	orchestrator *orchestrator.Orchestrator,
 	weboff chan bool,
@@ -42,13 +46,13 @@ func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 			true,
 		},
 		{
-			"/cache/clear",
+			clearUrl,
 			"clear cache entry for a given key. Omitting the key clears all cache entries. usage: `/cache/clear/<key>`",
 			clearCacheHandler(orchestrator),
 			true,
 		},
 		{
-			"/cache",
+			cacheUrl,
 			"print cache entry for a given key. Omitting the key outputs all cache entries. usage: `/cache/<key>`",
 			cacheDumpHandler(orchestrator),
 			true,
@@ -72,7 +76,7 @@ func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 			true,
 		},
 		{
-			"/log_level",
+			logUrl,
 			"update the log level to `debug`, `info`, `warn`, or `error`. " +
 				"Omitting the level outputs the current log level. usage: `/log_level/<level>`",
 			logLevelHandler(logger),
@@ -162,7 +166,7 @@ func getParam(path string, prefix string) string {
 func logLevelHandler(l log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "POST" {
-			logLevel := getParam(req.URL.Path, "/log_level")
+			logLevel := getParam(req.URL.Path, logUrl)
 
 			// If no key is provided, output the current log level.
 			if logLevel == "" {

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -24,9 +24,11 @@ type Handler struct {
 	redirect    bool
 }
 
-const logURL = "/log_level"
-const cacheURL = "/cache"
-const clearURL = "/cache/clear"
+const (
+	logURL   = "/log_level"
+	cacheURL = "/cache"
+	clearURL = "/cache/clear"
+)
 
 func getHandlers(bootstrap *bootstrapv1.Bootstrap,
 	orchestrator *orchestrator.Orchestrator,

--- a/internal/app/admin/http/handler.go
+++ b/internal/app/admin/http/handler.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"path/filepath"
 	"strings"
 
 	"github.com/envoyproxy/xds-relay/internal/pkg/log"
@@ -152,19 +153,16 @@ func configDumpHandler(bootstrapConfig *bootstrapv1.Bootstrap) http.HandlerFunc 
 	}
 }
 
-func getParam(path string) string {
-	// Assumes that the URL is of the format `address/endpoint/parameter` and returns `parameter`.
-	splitPath := strings.SplitN(path, "/", 3)
-	if len(splitPath) == 3 {
-		return splitPath[2]
-	}
-	return ""
+func getParam(path string, prefix string) string {
+	path = strings.TrimPrefix(path, prefix)
+	_, param := filepath.Split(path)
+	return param
 }
 
 func logLevelHandler(l log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "POST" {
-			logLevel := getParam(req.URL.Path)
+			logLevel := getParam(req.URL.Path, "/log_level")
 
 			// If no key is provided, output the current log level.
 			if logLevel == "" {

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"bytes"
 	"context"
-
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	"github.com/envoyproxy/xds-relay/internal/app/transport"
@@ -12,7 +11,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
-
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -84,20 +82,19 @@ func TestAdminServer_ConfigDumpHandler(t *testing.T) {
 }
 
 func TestGetParam(t *testing.T) {
-	path := "127.0.0.1:6070/cache/foo_production_*"
-	cacheKey := getParam(path)
+	path := "/cache/foo_production_*"
+	cacheKey := getParam(path, "/cache")
 	assert.Equal(t, "foo_production_*", cacheKey)
 }
 
 func TestGetParam_Empty(t *testing.T) {
-	path := "127.0.0.1:6070/cache/"
-	cacheKey := getParam(path)
+	prefix := "/cache"
+	path := "/cache/"
+	cacheKey := getParam(path, prefix)
 	assert.Equal(t, "", cacheKey)
-}
 
-func TestGetParam_Malformed(t *testing.T) {
-	path := "127.0.0.1:6070"
-	cacheKey := getParam(path)
+	path = "/cache"
+	cacheKey = getParam(path, prefix)
 	assert.Equal(t, "", cacheKey)
 }
 

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+
 	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	gcp "github.com/envoyproxy/go-control-plane/pkg/cache/v2"
 	"github.com/envoyproxy/xds-relay/internal/app/transport"
@@ -11,6 +12,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/stretchr/testify/assert"
+
 	"net/http"
 	"net/http/httptest"
 	"testing"

--- a/internal/app/admin/http/handler_test.go
+++ b/internal/app/admin/http/handler_test.go
@@ -112,7 +112,7 @@ func TestAdminServer_LogLevelHandler(t *testing.T) {
 	assert.Contains(t, output, "foo")
 	assert.NotContains(t, output, "bar")
 
-	req, err := http.NewRequest("POST", "/log_level/debug", nil)
+	req, err := http.NewRequest("POST", logURL+"/debug", nil)
 	assert.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -125,7 +125,7 @@ func TestAdminServer_LogLevelHandler(t *testing.T) {
 	output = buf.String()
 	assert.Contains(t, output, "bar")
 
-	req, err = http.NewRequest("POST", "/log_level/info", nil)
+	req, err = http.NewRequest("POST", logURL+"/info", nil)
 	assert.NoError(t, err)
 
 	handler.ServeHTTP(rr, req)
@@ -139,7 +139,7 @@ func TestAdminServer_LogLevelHandler(t *testing.T) {
 }
 
 func TestAdminServer_LogLevelHandler_GetLevel(t *testing.T) {
-	for _, url := range []string{"/log_level", "/log_level/"} {
+	for _, url := range []string{logURL, logURL} {
 		var buf bytes.Buffer
 		logger := log.NewMock("error", &buf)
 		assert.Equal(t, 0, buf.Len())
@@ -154,7 +154,7 @@ func TestAdminServer_LogLevelHandler_GetLevel(t *testing.T) {
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Equal(t, rr.Body.String(), "Current log level: error\n")
 
-		req, err = http.NewRequest("POST", "/log_level/info", nil)
+		req, err = http.NewRequest("POST", logURL+"/info", nil)
 		assert.NoError(t, err)
 
 		handler.ServeHTTP(rr, req)


### PR DESCRIPTION
Clear cache handler should have a path consisting of 4 entries (`address/cache/clear/x`). This change has it parse its own parameter instead of relying on `getParam()`
Signed-off-by: Samra Belachew <sbelachew@lyft.com>