### PR TITLE
Migrate example-management-server to v3 xDS APIs

### DIFF
--- a/example/config-files/aggregation-rules.yaml
+++ b/example/config-files/aggregation-rules.yaml
@@ -3,10 +3,10 @@ fragments:
       - match:
           request_type_match:
             types:
-              - "type.googleapis.com/envoy.api.v2.Listener"
-              - "type.googleapis.com/envoy.api.v2.Cluster"
-              - "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
-              - "type.googleapis.com/envoy.api.v2.RouteConfiguration"
+              - "type.googleapis.com/envoy.config.listener.v3.Listener"
+              - "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+              - "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"
+              - "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
         result:
           request_node_fragment:
             cluster_action:
@@ -15,32 +15,32 @@ fragments:
       - match:
           request_type_match:
             types:
-              - "type.googleapis.com/envoy.api.v2.Listener"
+              - "type.googleapis.com/envoy.config.listener.v3.Listener"
         result:
           string_fragment: "lds"
       - match:
           request_type_match:
             types:
-              - "type.googleapis.com/envoy.api.v2.Cluster"
+              - "type.googleapis.com/envoy.config.cluster.v3.Cluster"
         result:
           string_fragment: "cds"
       - match:
           request_type_match:
             types:
-              - "type.googleapis.com/envoy.api.v2.ClusterLoadAssignment"
+              - "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment"
         result:
           string_fragment: "eds"
       - match:
           request_type_match:
             types:
-              - "type.googleapis.com/envoy.api.v2.RouteConfiguration"
+              - "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
         result:
           string_fragment: "rds"
   - rules:
       - match:
           request_type_match:
             types:
-              - "type.googleapis.com/envoy.api.v2.RouteConfiguration"
+              - "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
         result:
           resource_names_fragment:
             element: 0

--- a/example/config-files/envoy-bootstrap-1.yaml
+++ b/example/config-files/envoy-bootstrap-1.yaml
@@ -9,7 +9,9 @@ admin:
       port_value: 19000
 dynamic_resources:
   cds_config:
+    resource_api_version: V3
     api_config_source:
+      transport_api_version: V3
       api_type: GRPC
       grpc_services:
       - envoy_grpc:

--- a/example/config-files/envoy-bootstrap-2.yaml
+++ b/example/config-files/envoy-bootstrap-2.yaml
@@ -9,7 +9,9 @@ admin:
       port_value: 19001
 dynamic_resources:
   cds_config:
+    resource_api_version: V3
     api_config_source:
+      transport_api_version: V3
       api_type: GRPC
       grpc_services:
       - envoy_grpc:

--- a/example/main.go
+++ b/example/main.go
@@ -10,17 +10,20 @@ import (
 
 	"google.golang.org/grpc"
 
-	api "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2"
-	"github.com/envoyproxy/go-control-plane/pkg/cache/v2"
-	xds "github.com/envoyproxy/go-control-plane/pkg/server/v2"
-	gcpresourcev2 "github.com/envoyproxy/go-control-plane/pkg/test/resource/v2"
+	clusterservice "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
+	discovery "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	endpointservice "github.com/envoyproxy/go-control-plane/envoy/service/endpoint/v3"
+	listenerservice "github.com/envoyproxy/go-control-plane/envoy/service/listener/v3"
+	routeservice "github.com/envoyproxy/go-control-plane/envoy/service/route/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	xds "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	gcpresourcev3 "github.com/envoyproxy/go-control-plane/pkg/test/resource/v3"
 )
 
 func generateTestSnapshotNewVersion(snapshotCache cache.SnapshotCache) {
 	// infinite loop where we wait for some time and override objects in the cache
 
-	snapshotConfig := gcpresourcev2.TestSnapshot{
+	snapshotConfig := gcpresourcev3.TestSnapshot{
 		Xds:              "xds",
 		UpstreamPort:     uint32(12000),
 		BasePort:         uint32(9000),
@@ -59,10 +62,10 @@ func runServer(snapshotCache cache.SnapshotCache, port int) {
 	listener, _ := net.Listen("tcp", fmt.Sprintf(":%d", port))
 
 	discovery.RegisterAggregatedDiscoveryServiceServer(grpcServer, server)
-	api.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
-	api.RegisterClusterDiscoveryServiceServer(grpcServer, server)
-	api.RegisterRouteDiscoveryServiceServer(grpcServer, server)
-	api.RegisterListenerDiscoveryServiceServer(grpcServer, server)
+	endpointservice.RegisterEndpointDiscoveryServiceServer(grpcServer, server)
+	clusterservice.RegisterClusterDiscoveryServiceServer(grpcServer, server)
+	routeservice.RegisterRouteDiscoveryServiceServer(grpcServer, server)
+	listenerservice.RegisterListenerDiscoveryServiceServer(grpcServer, server)
 
 	if err := grpcServer.Serve(listener); err != nil {
 		fmt.Println("something went wrong in the server")

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,7 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.7-0.20200812194826-9821e2beedf6 h1:TV0V+pjX0nS2oBnDyHJ0W1Gifjfs+qP645g43DwO7zo=
 github.com/envoyproxy/go-control-plane v0.9.7-0.20200812194826-9821e2beedf6/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
+github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.3.0 h1:Y2J74o+yAfcD8jpqtkLnUqRo+yshLr4eR1WPYGX0cic=


### PR DESCRIPTION
This patch migrates example-management-server to v3 xDS apis.
v2 xDS apis are deprecated and removed form Envoy in Q1 2021.

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>