### PR TITLE
Fix log format

### DIFF
--- a/internal/app/server/server.go
+++ b/internal/app/server/server.go
@@ -164,7 +164,7 @@ func RunWithContext(ctx context.Context, cancel context.CancelFunc, bootstrapCon
 				stopMutex.Unlock()
 			}
 		case sig := <-sigs:
-			logger.Info(ctx, "received interrupt signal:", sig.String())
+			logger.With("signal", sig.String()).Info(ctx, "received interrupt signal")
 			logger.Info(ctx, "initiating admin server shutdown")
 			if shutdownErr := adminServer.Shutdown(ctx); shutdownErr != nil {
 				logger.With("error", shutdownErr).Error(ctx, "admin shutdown error: ", shutdownErr.Error())


### PR DESCRIPTION
This patch make a tiny change which fixes a log format.

BFORE:
```
{"level":"info","ts":1609729155.4176533,"msg":"received interrupt signal:%!(EXTRA string=interrupt)","json":{}}
```

AFTER:
```
{"level":"info","ts":1609806458.4018972,"msg":"received interrupt signal","json":{"signal":"interrupt"}}
```

Signed-off-by: Kenjiro Nakayama <nakayamakenjiro@gmail.com>