### PR TITLE
upstream client: Handle recv() blocked scenarios

### DIFF
--- a/internal/app/orchestrator/orchestrator.go
+++ b/internal/app/orchestrator/orchestrator.go
@@ -310,7 +310,7 @@ func (o *orchestrator) watchUpstream(
 				// TODO if set fails, we may need to retry upstream as well.
 				// Currently the fallback is to rely on a future response, but
 				// that probably isn't ideal.
-				// https://github.com/envoyproxy/xds-relay/issues/70s
+				// https://github.com/envoyproxy/xds-relay/issues/70
 				//
 				// If we fail to cache the new response, log and return the old one.
 				o.logger.With("error", err).With("aggregated_key", aggregatedKey).
@@ -388,6 +388,11 @@ func (o *orchestrator) fanout(resp transport.Response, watchers *cache.RequestsS
 	o.scope.Timer(metrics.TimerFanoutTime).Record(time.Since(start))
 	// Wait for all fanouts to complete.
 	wg.Wait()
+	o.logger.With(
+		"aggregated_key", aggregatedKey,
+		"response_type", resp.GetTypeURL(),
+		"response_version", resp.GetPayloadVersion(),
+	).Debug(context.Background(), "response fanout complete")
 	o.scope.Timer(metrics.TimerSendTime).Record(time.Since(start))
 }
 

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -286,7 +286,7 @@ func send(
 		case sig, ok := <-signal:
 			if !ok {
 				logger.With("aggregated_key", aggregatedKey).Debug(ctx, "send() chan closed")
-				ctx.Done()
+				cancelFunc()
 				return
 			}
 			logger.With("aggregated_key", aggregatedKey,

--- a/internal/app/upstream/client.go
+++ b/internal/app/upstream/client.go
@@ -310,6 +310,8 @@ func send(
 
 // recv is an infinite loop which blocks on RecvMsg.
 // The only ways to exit the goroutine is by cancelling the context or when an error occurs.
+// response channel is used by the caller (orchestrator) to propagate responses to downstream clients.
+// signal channel is read by send() in order to send an ACK to the upstream client.
 func recv(
 	ctx context.Context,
 	complete func(),
@@ -321,6 +323,7 @@ func recv(
 	aggregatedKey string) {
 	defer complete()
 	for {
+		logger.With("aggregated_key", aggregatedKey).Debug(ctx, "recv(): listening for message")
 		resp, err := stream.RecvMsg()
 		if err != nil {
 			handleError(ctx, logger, aggregatedKey, "Error in RecvMsg", cancelFunc, err)


### PR DESCRIPTION
There are two error scenarios currently that leads to cache drifts
between the management server and xds-relay.

1. There is a bug where the stream is stuck indefinitely if the send chan
is closed unexpectedly. The recv routine stays open and the waitgroup
never completes, blocking retries.

2. If the response receiver channel for `recv()` is blocked, the upstream
client is blocked from sending ACKs back to the management server.

Signed-off-by: Jess Yuen <jyuen@lyft.com>